### PR TITLE
Improve logging format and update GRUB gfxmode for auto-picking best …

### DIFF
--- a/config/grub.cfg
+++ b/config/grub.cfg
@@ -55,7 +55,7 @@ insmod font
 insmod png
 
 # Configure the graphics mode and autoboot time
-set gfxmode=1920x1080,1024x768,800x600auto
+set gfxmode=auto
 set gfxpayload=keep
 set timeout=5
 
@@ -88,7 +88,7 @@ function cpu_props {
         cpu_bits="32"
 	fi
 
-    echo "This machine has a $cpu_bits-bit processor that $pae_assessment PAE."
+    echo "This machine has a $cpu_bits-bit $grub_cpu processor that $pae_assessment PAE."
 }
 
 # Menu entries
@@ -141,7 +141,8 @@ submenu "Advanced Options →" {
 
     menuentry "Bootloader Info" {
         echo "[== BOOTLOADER INFO ==]"
-        echo "Bootloader: GNU GRUB ${grub_version}"
+        echo "Bootloader: GNU GRUB ${grub_version}$package_version"
+        echo "Platform: $grub_platform"
         echo "Prefix: $prefix"
         echo "Root device: $root"
         echo $"Press ESC to return to the main menu..."

--- a/src/Core/Interrupts/IDT.c
+++ b/src/Core/Interrupts/IDT.c
@@ -53,7 +53,7 @@ void irq_handler(uint8_t irq) {
 }
 
 void exception_handler(uint32_t err) {
-    PRINTF("Exception occurred! '%s'\n", IDTExceptionStrings[err]);
+    LOGF(LOG_ERROR, "CPU exception occurred! '%s'\n", IDTExceptionStrings[err]);
     if (KernelIDT.ExceptionHandlers[err]) {
         KernelIDT.ExceptionHandlers[err](err);
         return;
@@ -64,8 +64,8 @@ void exception_handler(uint32_t err) {
 }
 
 static void TestingExceptionHandler(uint32_t exceptionNumber) {
-    PRINTF("Exception handled successfully in testing mode. Exception number: %d\n", exceptionNumber);
-    PRINTF("Error string: %s\n", IDTExceptionStrings[exceptionNumber]);
+    LOGF(LOG_INFO, "Exception handled successfully in testing mode. Exception number: %d\n", exceptionNumber);
+    PRINTF("    * Error string: %s\n\n", IDTExceptionStrings[exceptionNumber]);
 }
 
 Status IDTInit() {
@@ -88,7 +88,7 @@ Status IDTInit() {
     ASM ("sti");
 
     // Test the IDT by setting some exception handlers and triggering them
-    PRINT("Testing IDT by triggering exceptions...\n");
+    LOG(LOG_INFO, "Testing IDT by triggering exceptions...\n");
 
     IDTSetExceptionHandler(0, TestingExceptionHandler); // Division By Zero
     IDTSetExceptionHandler(3, TestingExceptionHandler); // Breakpoint
@@ -97,7 +97,7 @@ Status IDTInit() {
     ASM ("int $0"); // Trigger Division By Zero
     ASM ("int $3"); // Trigger Breakpoint
 
-    PRINT("IDT initialized and tested successfully.\n");
+    LOG(LOG_INFO, "IDT initialized and tested successfully.\n");
 
     KernelIDT.ExceptionHandlers[0] = nullptr; // Remove the testing handler
     KernelIDT.ExceptionHandlers[3] = nullptr; // Remove the testing handler

--- a/src/Core/Kernel.c
+++ b/src/Core/Kernel.c
@@ -1,5 +1,6 @@
 #include "Kernel.h"
 
+#include <Definitions.h>
 #include <stdarg.h>
 #include <Drivers/Graphics/DefaultFont.h>
 #include <Drivers/Graphics/Framebuffer.h>
@@ -10,23 +11,36 @@
 
 KernelState Kernel = {};
 
-static NORETURN void serial_panic(const char* message) {
-    SerialWriteString(&Kernel.Serial, "\nPanic!\n");
+static NORETURN void KernelPanic(const char* message)
+{
+    // Store the previous terminal foreground color
+    uint32_t prevFGColor = FramebufferConsole.ForegroundColor;
+
+    // Serial doesn't usually have color, so we just print the message as-is
+    SerialWriteString(&Kernel.Serial, "[== KERNEL PANIC ==]\n");
     SerialWriteString(&Kernel.Serial, message);
-    FramebufferConsoleWriteString("\nPanic!\n");
+
+    // Our framebuffer *does* have color, so we can make certain text colored!
+    FramebufferConsoleWriteString("[== ");
+
+    FramebufferConsole.ForegroundColor = COLOR_RED;
+    FramebufferConsoleWriteString("KERNEL PANIC");
+
+    FramebufferConsole.ForegroundColor = prevFGColor;
+    FramebufferConsoleWriteString(" ==]\n");
     FramebufferConsoleWriteString(message);
+
+    // Disable interrupts so the CPU doesn't try to handle anything while we're halted
     ASM("cli");
-    while (true) {
+
+    while (true)
+    {
         ASM("hlt");
     }
 }
 
-static void serial_log(const char* message) {
-    SerialWriteString(&Kernel.Serial, message);
-    FramebufferConsoleWriteString(message);
-}
-
-static void serial_printf(const char* format, ...) {
+static void KernelPrintf(const char* format, ...)
+{
     char buffer[512];
     va_list args;
     va_start(args, format);
@@ -41,10 +55,74 @@ static void serial_printf(const char* format, ...) {
     }
 }
 
+static void KernelLog(int log_type, const char* format, ...)
+{
+    // Define a temporary buffer and insert the arguments into the string
+    char msg_buffer[512];
+    va_list fmt_args;
+    va_start(fmt_args, format);
+    size_t written = VStringFormat(msg_buffer, sizeof(msg_buffer), format, fmt_args);
+    va_end(fmt_args);
+
+    // Store the previous foreground color so we don't force a color reset
+    uint32_t prevFGColor = FramebufferConsole.ForegroundColor;
+
+    // Write the log type in colored text, and the message in the default terminal foreground color
+    FramebufferConsolePutChar('[');
+    SerialWriteChar(&Kernel.Serial, '[');
+
+    switch(log_type)
+    {
+        case LOG_WARNING:
+            FramebufferConsole.ForegroundColor = COLOR_YELLOW;
+            FramebufferConsoleWriteString("WARN");
+            SerialWriteString(&Kernel.Serial, "WARN");
+            break;
+
+        case LOG_ERROR:
+            FramebufferConsole.ForegroundColor = COLOR_RED;
+            FramebufferConsoleWriteString("ERROR");
+            SerialWriteString(&Kernel.Serial, "ERROR");
+            break;
+
+        case LOG_CRITICAL:
+            FramebufferConsole.ForegroundColor = COLOR_MAROON;
+            FramebufferConsoleWriteString("CRITICAL");
+            SerialWriteString(&Kernel.Serial, "CRITICAL");
+            break;
+
+        case LOG_DEBUG:
+            FramebufferConsole.ForegroundColor = COLOR_CYAN;
+            FramebufferConsoleWriteString("DEBUG");
+            SerialWriteString(&Kernel.Serial, "DEBUG");
+            break;
+
+        case LOG_INFO:
+        default:
+            FramebufferConsole.ForegroundColor = COLOR_GREEN;
+            FramebufferConsoleWriteString("INFO");
+            SerialWriteString(&Kernel.Serial, "INFO");
+            break;
+    }
+
+    FramebufferConsole.ForegroundColor = prevFGColor;
+    FramebufferConsoleWriteString("] ");
+    FramebufferConsoleWriteString(msg_buffer);
+    SerialWriteString(&Kernel.Serial, "] ");
+    SerialWriteString(&Kernel.Serial, msg_buffer);
+
+    // If the buffer was too small, notify the user that it's been truncated
+    if (written >= sizeof(msg_buffer))
+    {
+        FramebufferConsoleWriteString("...(truncated)\n");
+        SerialWriteString(&Kernel.Serial, "...(truncated)\n");
+    }
+}
+
 Status KernelInit(uint32_t InfoPtr) {
-    Kernel.Panic = serial_panic; // For now, just use the serial functions.
-    Kernel.Log = serial_log;
-    Kernel.Printf = serial_printf;
+    Kernel.Panic = KernelPanic;
+    Kernel.Log = KernelLog;
+    Kernel.Printf = KernelPrintf;
 
     if (SerialInit(SERIAL_COM1) != STATUS_SUCCESS) {
         // We can't use serial, this probably means this is running on a real machine without a serial port.
@@ -58,12 +136,12 @@ Status KernelInit(uint32_t InfoPtr) {
         PANIC("Failed to initialize Framebuffer!\n");
     }
 
-    if (FramebufferConsoleInit(KernelFramebuffer.Width / FONT_WIDTH, KernelFramebuffer.Height / FONT_HEIGHT, COLOR_WHITE, OURBLE) != STATUS_SUCCESS) {
+    if (FramebufferConsoleInit(KernelFramebuffer.Width / FONT_WIDTH, KernelFramebuffer.Height / FONT_HEIGHT, COLOR_LIGHTGRAY, OURBLE) != STATUS_SUCCESS) {
         PANIC("Failed to initialize Framebuffer Console!\n");
     }
 
-    LOG("Serial initialized successfully.\n");
-    Kernel.Printf("Loading kernel version: %z.%z.%z.\n", BOREALOS_MAJOR_VERSION, BOREALOS_MINOR_VERSION, BOREALOS_PATCH_VERSION);
+    Kernel.Printf("[== BorealOS %z.%z.%z ==]\n", BOREALOS_MAJOR_VERSION, BOREALOS_MINOR_VERSION, BOREALOS_PATCH_VERSION);
+    LOG(LOG_INFO, "Serial initialized successfully.\n");
 
     // Now load the physical memory manager
     if (PhysicalMemoryManagerInit(InfoPtr) != STATUS_SUCCESS) {
@@ -74,21 +152,21 @@ Status KernelInit(uint32_t InfoPtr) {
         PANIC("Physical Memory Manager test failed!\n");
     }
 
-    Kernel.Printf("Physical Memory Manager initialized successfully. With %z pages of memory (%z MiB).\n", KernelPhysicalMemoryManager.TotalPages, (KernelPhysicalMemoryManager.TotalPages * 4096) / (1024 * 1024));
-    Kernel.Printf("Physical Memory Manager has %z bytes for allocation & reservation maps.\n", KernelPhysicalMemoryManager.MapSize * 2);
+    LOGF(LOG_INFO, "Physical Memory Manager initialized successfully (%z pages totaling %z MiB).\n", KernelPhysicalMemoryManager.TotalPages, (KernelPhysicalMemoryManager.TotalPages * 4096) / (1024 * 1024));
+    LOGF(LOG_INFO, "Physical Memory Manager has %z bytes for allocation & reservation maps.\n", KernelPhysicalMemoryManager.MapSize * 2);
 
     // Load the PIC
     if (PICInit(0x20, 0x28) != STATUS_SUCCESS) {
         PANIC("Failed to initialize PIC!\n");
     }
-    LOG("PIC initialized successfully.\n");
+    LOG(LOG_INFO, "PIC initialized successfully.\n");
 
     // Load the IDT
     if (IDTInit() != STATUS_SUCCESS) {
         PANIC("Failed to initialize IDT!\n");
     }
 
-    LOG("IDT initialized successfully.\n");
+    LOG(LOG_INFO, "IDT initialized successfully.\n");
 
     if (PagingInit(&Kernel.Paging) != STATUS_SUCCESS) {
         PANIC("Failed to initialize Paging!\n");
@@ -101,11 +179,11 @@ Status KernelInit(uint32_t InfoPtr) {
         PANIC("Paging test failed!\n");
     }
 
-    LOG("Paging initialized successfully.\n");
+    LOG(LOG_INFO, "Paging initialized successfully.\n");
 
-    // Map in the framebuffer to the kernel's virtual address space.
+    // Map in the framebuffer to the kernel's virtual address space and enable write access for the framebuffer.
     FramebufferMapSelf(&Kernel.Paging);
-    KernelFramebuffer.CanUse = true; // Now we can use the framebuffer for drawing
+    KernelFramebuffer.CanUse = true;
 
     // ONLY AFTER HERE IS IT SAFE TO LOG TO THE FRAMEBUFFER.
 
@@ -114,7 +192,6 @@ Status KernelInit(uint32_t InfoPtr) {
         PANIC("Failed to initialize Kernel Virtual Memory Manager!\n");
     }
 
-    Kernel.Printf("Kernel Virtual Memory Manager initialized successfully.\n");
-
+    LOG(LOG_INFO, "Kernel Virtual Memory Manager initialized successfully.\n");
     return STATUS_SUCCESS;
 }

--- a/src/Core/Kernel.h
+++ b/src/Core/Kernel.h
@@ -10,7 +10,7 @@
 #include "Memory/Paging.h"
 #include "Memory/VirtualMemoryManager.h"
 
-typedef void (*LogFn)(const char*);
+typedef void (*LogFn)(int, const char*, ...);
 typedef NORETURN void (*PanicFn)(const char*);
 typedef void (*PrintfFn)(const char*, ...);
 

--- a/src/Core/Memory/Paging.c
+++ b/src/Core/Memory/Paging.c
@@ -1,3 +1,4 @@
+#include <Definitions.h>
 #include "Paging.h"
 #include "Core/Kernel.h"
 #include "PhysicalMemoryManager.h"
@@ -159,7 +160,7 @@ Status PagingTest(PagingState *state) {
         PANIC("PagingTest: Failed to read/write to mapped page!\n");
     }
 
-    PRINTF("Successfully wrote %p to %p at real address %p!\n", *ptr, address, page);
+    LOGF(LOG_INFO, "Successfully wrote %p to %p at real address %p!\n", *ptr, address, page);
 
     if (PagingTranslate(state, address) != page) {
         PANIC("PagingTest: Translated address does not match physical page!\n");
@@ -169,7 +170,7 @@ Status PagingTest(PagingState *state) {
         PANIC("PagingTest: Failed to unmap page!\n");
     }
 
-    PRINT("Paging test completed successfully.\n");
+    LOG(LOG_INFO, "Paging test completed successfully.\n");
 
 
     return STATUS_SUCCESS;

--- a/src/Core/Memory/PhysicalMemoryManager.c
+++ b/src/Core/Memory/PhysicalMemoryManager.c
@@ -158,7 +158,7 @@ Status PhysicalMemoryManagerFreePage(void *page) {
 }
 
 Status PhysicalMemoryManagerTest(void) {
-    PRINT("Testing Physical Memory Manager...\n");
+    LOG(LOG_INFO, "Testing Physical Memory Manager...\n");
     void* page1 = PhysicalMemoryManagerAllocatePage();
     if (!page1) {
         PANIC("Failed to allocate page 1!\n");
@@ -195,7 +195,7 @@ Status PhysicalMemoryManagerTest(void) {
     if (!success) {
         PANIC("Memory test failed! Data corruption detected!\n");
     }
-    PRINT("Memory test passed! Freeing pages...\n");
+    LOG(LOG_INFO, "Memory test passed! Freeing pages...\n");
 
     if (PhysicalMemoryManagerFreePage(page1) != STATUS_SUCCESS) {
         PANIC("Failed to free page 1!\n");
@@ -205,6 +205,6 @@ Status PhysicalMemoryManagerTest(void) {
         PANIC("Failed to free page 2!\n");
     }
 
-    PRINT("Pages freed successfully.\n");
+    PRINT("    * Pages freed successfully.\n\n");
     return STATUS_SUCCESS;
 }

--- a/src/Definitions.h
+++ b/src/Definitions.h
@@ -52,18 +52,22 @@ typedef enum {
     STATUS_FAILURE = -1,
 } Status;
 
+typedef enum {
+    LOG_INFO = 0,
+    LOG_WARNING = 1,
+    LOG_ERROR = 2,
+    LOG_CRITICAL = 3,
+    LOG_DEBUG = 4,
+} KernelLogType;
+
 // Log structure:
-// [TYPE] [FILE:LINE] : message
-#define LOG_INFO(message) (Kernel.Log("[INFO] [" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
-#define LOG_WARNING(message) (Kernel.Log("[WARNING] [" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
-#define LOG_ERROR(message) (Kernel.Log("[ERROR] [" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
-#define LOG_CRITICAL(message) (Kernel.Log("[CRITICAL] " __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
-#define LOG_DEBUG(message) (Kernel.Log("[DEBUG] [" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
-#define LOG(message) LOG_INFO(message)
+// [TYPE] [FILE:LINE] >> message
+#define LOGF(logtype, message, ...) (Kernel.Log(logtype, "[" __FILE_NAME__ ":" STR(__LINE__) "] >> " message, __VA_ARGS__))
+#define LOG(logtype, message) (Kernel.Log(logtype, "[" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
 
 #define PRINTF(format, ...) (Kernel.Printf(format, __VA_ARGS__))
 #define PRINT(string) (Kernel.Printf(string))
 
-#define PANIC(message) (Kernel.Panic("[PANIC] [" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
+#define PANIC(message) (Kernel.Panic("[" __FILE_NAME__ ":" STR(__LINE__) "] >> " message))
 
 #endif //BOREALOS_DEFINITIONS_H

--- a/src/Drivers/Graphics/Framebuffer.c
+++ b/src/Drivers/Graphics/Framebuffer.c
@@ -10,14 +10,14 @@ FramebufferConfig KernelFramebuffer = {};
 
 Status FramebufferInit(uint32_t InfoPtr)
 {
-    PRINT("Initializing framebuffer...\n");
+    LOG(LOG_INFO, "Initializing framebuffer...\n");
 
     // Attempt to get the framebuffer information using multiboot2; if the request failed, return a failure status and don't try to init further
     struct multiboot_tag_framebuffer_common* FBInfo = MBGetTag(InfoPtr, MULTIBOOT_TAG_TYPE_FRAMEBUFFER);
 
     if (!FBInfo)
     {
-        PRINT("Failed to get framebuffer information from multiboot2!\n");
+        LOG(LOG_ERROR, "Failed to get framebuffer information from multiboot2!\n");
         return STATUS_FAILURE;
     }
 
@@ -30,7 +30,7 @@ Status FramebufferInit(uint32_t InfoPtr)
     KernelFramebuffer.CanUse = true;
 
     // Print the framebuffer properties
-    PRINTF("Framebuffer at address %p is set up for %ux%u@%u\n",
+    LOGF(LOG_INFO, "Framebuffer at address %p is set up for %ux%u@%u\n",
         KernelFramebuffer.Address,
         KernelFramebuffer.Width,
         KernelFramebuffer.Height,

--- a/src/Drivers/IO/FramebufferConsole.c
+++ b/src/Drivers/IO/FramebufferConsole.c
@@ -39,7 +39,7 @@ void FramebufferConsolePutChar(char c) {
         FramebufferConsole.CursorX++;
     }
 
-    if (FramebufferConsole.CursorX >= FramebufferConsole.Width)
+    if (FramebufferConsole.CursorX > FramebufferConsole.Width)
     {
         FramebufferConsole.CursorX = 0;
         FramebufferConsole.CursorY++;


### PR DESCRIPTION
… screen resolution


Drivers/IO/FramebufferConsole.c:
- Fixed a bug on line 42 where the terminal wraps around prematurely when text exceeds the console width


Definitions.h:
- Replaced separate log macros with a LogType enum
- Added LOG and LOGF for normal and formatted kernel log messages
- Removed "[== KERNEL PANIC ==]" text, the kernel panic function will print that now


Drivers/Graphics/Framebuffer.c:
Core/Memory/PhysicalMemoryManager.c:
Core/Memory/Paging.c:
Core/Interrupts/IDT.c:
- Updated logging to use LOGF and LOG instead of PRINTF


Core/Kernel.h:
- Updated LogFn definition to allow for va_args


Core/Kernel.c:
- Replaced serial_* logging functions with Kernel* versions that output to both serial and the framebuffer console


config/grub.cfg:
- Added CPU arch to processor information menuentry
- Added package version  to bootloader info menuentry
- gfxmode no longer specifies resolutions nd instead picks the best one automatically