### PR TITLE
Start ACPI impl. & fix fbcon width char cutoff bug

### DIFF
--- a/src/Core/Firmware/ACPI.c
+++ b/src/Core/Firmware/ACPI.c
@@ -1,0 +1,184 @@
+#include <Definitions.h>
+#include "ACPI.h"
+#include "Utility/SerialOperations.h"
+#include "Utility/StringTools.h"
+#include "Boot/multiboot.h"
+#include "Boot/MBParser.h"
+#include "Core/Kernel.h"
+
+ACPIState ACPI = {};
+const char* PowerProfileStrings[8] = {"Unspecified", "Desktop", "Mobile", "Workstation", "Enterprise Server", "SOHO Server", "Appliance PC", "Performance Server"};
+void* SDPAddr = NULL;
+bool useNewACPI = false;
+
+struct FADT_t* FindFADT(struct RSDT_t* RSDT)
+{
+    int entries = (RSDT->SDTHeader.Length - sizeof(RSDT->SDTHeader)) / 4;
+
+    for (int i = 0; i < entries; i++)
+    {
+        struct ACPISDTHeader* SDTHeader = (struct ACPISDTHeader*) RSDT->PointerToOtherSDT[i];
+
+        if (!strncmp(SDTHeader->Signature, "FACP", 4))
+        {
+            return (struct FADT_t*)SDTHeader;
+        }
+    }
+
+    // No FADT was found
+    return NULL;
+}
+
+bool ValidateSDPSDTChecksum(void* table, size_t length) {
+    // The sum of all the fields should be zero
+    uint8_t* bytes = (uint8_t*)table;
+    uint8_t sum = 0;
+
+    for (size_t i = 0; i < length; i++)
+    {
+        sum += bytes[i];
+    }
+
+    return sum == 0;
+}
+
+bool ValidateXSDPTable(struct XSDP_t* xsdp){
+    // Check the first 20 bytes as if it were an RSDP struct
+    if (!ValidateSDPSDTChecksum(xsdp, RSDP_TABLE_LEN))
+    {
+        return false;
+    }
+
+    // Now we have to check entire extended structure
+    if (!ValidateSDPSDTChecksum(xsdp, xsdp->Length)) {
+        return false;
+    }
+    return true;
+}
+
+Status ACPIInit(uint32_t MB2InfoPtr) {
+    ACPI.Initialized = false;
+
+    // Attempt to get the *SDP via ACPI 2.0+; if this fails, try again with ACPI 1.0
+    struct multiboot_tag_new_acpi* newACPITag = (struct multiboot_tag_new_acpi*)MBGetTag(MB2InfoPtr, MULTIBOOT_TAG_TYPE_ACPI_NEW);
+    if (newACPITag)
+    {
+        SDPAddr = (void*)newACPITag->rsdp;
+        useNewACPI = true;
+    }
+    else
+    {
+        // The tag for ACPI 2.0+ wasn't found, we should try looking for the ACPI 1.0 tag
+        struct multiboot_tag_old_acpi* oldACPITag = (struct multiboot_tag_old_acpi*)MBGetTag(MB2InfoPtr, MULTIBOOT_TAG_TYPE_ACPI_OLD);
+
+        if (oldACPITag)
+        {
+            SDPAddr = (void*)oldACPITag->rsdp;
+        }
+    }
+
+    // Make sure we got an SDP address
+    if (!SDPAddr)
+    {
+        LOG(LOG_WARNING, "Failed to get ACPI *SDP address, ACPI initialization cannot continue.\n");
+        return STATUS_FAILURE;
+    }
+
+    // Make sure the address we got is valid
+    if ((uintptr_t)SDPAddr >= RSDP_SEARCH_REGION_START && (uintptr_t)SDPAddr <= RSDP_SEARCH_REGION_END)
+    {
+        LOGF(LOG_WARNING, "ACPI *SDP address 0x%x is out of range (0x%x-0x%x)!\n", (uint64_t)(uintptr_t)SDPAddr, (uint64_t)RSDP_SEARCH_REGION_START, (uint64_t)RSDP_SEARCH_REGION_END);
+        return STATUS_FAILURE;
+    }
+
+    LOGF(LOG_INFO, "*SDP address is 0x%x\n", (uint64_t)(uintptr_t)SDPAddr);
+    LOGF(LOG_INFO, "ACPI %s structs will be used.\n", useNewACPI == true ? "2.0+" : "1.0");
+
+    // We need to set up the correct *SDT table
+    if (useNewACPI == true)
+    {
+        ACPI.XSDP = (struct XSDP_t*)SDPAddr;
+        LOG(LOG_INFO, "Validating XSDP table...\n");
+        
+        if (ValidateXSDPTable(ACPI.XSDP) == false)
+        {
+            LOG(LOG_ERROR, "XSDP table checksum failed!");
+            return STATUS_FAILURE;
+        }
+
+        // Now we need to validate both the RSDT and XSDT
+        LOGF(LOG_INFO, "RSDT address is 0x%x.\n", (uint64_t)(uintptr_t)ACPI.XSDP->RsdtAddress);
+        LOGF(LOG_INFO, "XSDT address is 0x%x.\n", (uint64_t)(uintptr_t)ACPI.XSDP->XsdtAddress);
+        ACPI.RSDT = (struct RSDT_t*)ACPI.XSDP->RsdtAddress;
+        ACPI.XSDT = (struct XSDT_t*)(uintptr_t)ACPI.XSDP->XsdtAddress;
+    }
+    else
+    {
+        // Cast and validate the RSDP table
+        ACPI.RSDP = (struct RSDP_t*)SDPAddr;
+        LOG(LOG_INFO, "Validating RSDP table...\n");
+
+        if (ValidateSDPSDTChecksum(ACPI.RSDP, RSDP_TABLE_LEN) == false)
+        {
+            LOG(LOG_ERROR, "RSDP table checksum failed!");
+            return STATUS_FAILURE;
+        }
+        
+        // Now we need to validate the RSDT
+        LOGF(LOG_INFO, "RSDT address is 0x%x.\n", (uint64_t)(uintptr_t)ACPI.RSDP->RsdtAddress);
+        ACPI.RSDT = (struct RSDT_t*)ACPI.RSDP->RsdtAddress;
+        LOG(LOG_INFO, "Validating RSDT...\n");
+
+        if (ValidateSDPSDTChecksum(ACPI.RSDT, ACPI.RSDT->SDTHeader.Length) == false)
+        {
+            LOG(LOG_ERROR, "RSDT table checksum failed!");
+            return STATUS_FAILURE;
+        }
+    }
+
+    // Find the FADT
+    ACPI.FADT = FindFADT(ACPI.RSDT);
+
+    if (!ACPI.FADT)
+    {
+        LOG(LOG_WARNING, "Failed to get ACPI FADT address!\n");
+        return STATUS_FAILURE;
+    }
+
+    LOGF(LOG_INFO, "FADT address is 0x%x.\n", (uint64_t)(uintptr_t)ACPI.FADT);
+
+    // Enable ACPI power management mode if we can
+    if (ACPI.FADT->SMI_CommandPort != 0 && ACPI.FADT->AcpiEnable != 0)
+    {
+        LOG(LOG_INFO, "Enabling ACPI power management events...\n");
+        outb(ACPI.FADT->SMI_CommandPort, ACPI.FADT->AcpiEnable);
+
+        // Wait for ACPI to be enabled by polling the PM1aControlBlock register
+        while (true)
+        {
+            if (inw(ACPI.FADT->PM1aControlBlock) & (1 << 0))
+            {
+                break;
+            }
+        }
+    }
+    else
+    {
+        LOG(LOG_INFO, "ACPI power management events are either unsupported or already enabled.\n");
+    }
+
+    // We should store the power profile for later
+    if (ACPI.FADT->PreferredPowerManagementProfile < 8)
+    {
+        LOGF(LOG_INFO, "Device preferred power management profile is \"%s\" (profile #%u)\n", PowerProfileStrings[ACPI.FADT->PreferredPowerManagementProfile], ACPI.FADT->PreferredPowerManagementProfile);
+        ACPI.ValidPowerMGMTMode = true;
+    }
+    else
+    {
+        LOGF(LOG_WARNING, "Profile #%u is not a valid power management profile, values must be 0-7.\n", ACPI.FADT->PreferredPowerManagementProfile);
+        ACPI.ValidPowerMGMTMode = false;
+    }
+    
+    ACPI.Initialized = true;
+    return STATUS_SUCCESS;
+}

--- a/src/Core/Firmware/ACPI.h
+++ b/src/Core/Firmware/ACPI.h
@@ -9,15 +9,16 @@
 #define RSDP_TABLE_LEN 20
 #define RSDP_SEARCH_STR "RSD PTR "
 
-PACKED struct RSDP_t {
+// These structs were provided by the OSDEV wiki, and have been edited to comply with this project's code standards
+typedef struct {
     char Signature[8];
     uint8_t Checksum;
     char OEMID[6];
     uint8_t Revision;
     uint32_t RsdtAddress;
-};
+} PACKED RSDP_t;
 
-PACKED struct XSDP_t {
+typedef struct  {
  char Signature[8];
  uint8_t Checksum;
  char OEMID[6];
@@ -28,18 +29,17 @@ PACKED struct XSDP_t {
  uint64_t XsdtAddress;
  uint8_t ExtendedChecksum;
  uint8_t reserved[3];
-};
+} PACKED XSDP_t;
 
-struct GenericAddr
-{
+typedef struct {
   uint8_t AddressSpace;
   uint8_t BitWidth;
   uint8_t BitOffset;
   uint8_t AccessSize;
   uint64_t Address;
-};
+} GenericAddr;
 
-struct ACPISDTHeader {
+typedef struct {
   char Signature[4];
   uint32_t Length;
   uint8_t Revision;
@@ -49,11 +49,10 @@ struct ACPISDTHeader {
   uint32_t OEMRevision;
   uint32_t CreatorID;
   uint32_t CreatorRevision;
-};
+} ACPISDTHeader;
 
-struct FADT_t
-{
-    struct   ACPISDTHeader SDTHeader;
+typedef struct {
+    ACPISDTHeader SDTHeader;
     uint32_t FirmwareCtrl;
     uint32_t Dsdt;
 
@@ -100,7 +99,7 @@ struct FADT_t
     uint32_t Flags;
 
     // 12 byte structure; see below for details
-    struct GenericAddr ResetReg;
+    GenericAddr ResetReg;
 
     uint8_t  ResetValue;
     uint8_t  Reserved3[3];
@@ -109,32 +108,32 @@ struct FADT_t
     uint64_t                X_FirmwareControl;
     uint64_t                X_Dsdt;
 
-    struct GenericAddr X_PM1aEventBlock;
-    struct GenericAddr X_PM1bEventBlock;
-    struct GenericAddr X_PM1aControlBlock;
-    struct GenericAddr X_PM1bControlBlock;
-    struct GenericAddr X_PM2ControlBlock;
-    struct GenericAddr X_PMTimerBlock;
-    struct GenericAddr X_GPE0Block;
-    struct GenericAddr X_GPE1Block;
-};
+    GenericAddr X_PM1aEventBlock;
+    GenericAddr X_PM1bEventBlock;
+    GenericAddr X_PM1aControlBlock;
+    GenericAddr X_PM1bControlBlock;
+    GenericAddr X_PM2ControlBlock;
+    GenericAddr X_PMTimerBlock;
+    GenericAddr X_GPE0Block;
+    GenericAddr X_GPE1Block;
+} FADT_t;
 
-struct RSDT_t {
-  struct ACPISDTHeader SDTHeader;
+typedef struct {
+  ACPISDTHeader SDTHeader;
   uint32_t PointerToOtherSDT[];
-};
+} RSDT_t;
 
-struct XSDT_t {
-  struct ACPISDTHeader SDTHeader;
+typedef struct {
+  ACPISDTHeader SDTHeader;
   uint64_t PointerToOtherSDT[];
-};
+} XSDT_t;
 
-typedef struct ACPIState {
-    struct RSDP_t* RSDP;
-    struct XSDP_t* XSDP;
-    struct RSDT_t* RSDT;
-    struct XSDT_t* XSDT;
-    struct FADT_t* FADT;
+typedef struct {
+    RSDP_t* RSDP;
+    XSDP_t* XSDP;
+    RSDT_t* RSDT;
+    XSDT_t* XSDT;
+    FADT_t* FADT;
     bool ValidPowerMGMTMode;
     bool Initialized;
 } ACPIState;

--- a/src/Core/Firmware/ACPI.h
+++ b/src/Core/Firmware/ACPI.h
@@ -1,0 +1,147 @@
+#ifndef BOREALOS_ACPI_H
+#define BOREALOS_ACPI_H
+
+#include <Definitions.h>
+#include "ACPI.h"
+
+#define RSDP_SEARCH_REGION_START 0x000E0000
+#define RSDP_SEARCH_REGION_END 0x000FFFFF
+#define RSDP_TABLE_LEN 20
+#define RSDP_SEARCH_STR "RSD PTR "
+
+PACKED struct RSDP_t {
+    char Signature[8];
+    uint8_t Checksum;
+    char OEMID[6];
+    uint8_t Revision;
+    uint32_t RsdtAddress;
+};
+
+PACKED struct XSDP_t {
+ char Signature[8];
+ uint8_t Checksum;
+ char OEMID[6];
+ uint8_t Revision;
+ uint32_t RsdtAddress;      // deprecated since version 2.0
+
+ uint32_t Length;
+ uint64_t XsdtAddress;
+ uint8_t ExtendedChecksum;
+ uint8_t reserved[3];
+};
+
+struct GenericAddr
+{
+  uint8_t AddressSpace;
+  uint8_t BitWidth;
+  uint8_t BitOffset;
+  uint8_t AccessSize;
+  uint64_t Address;
+};
+
+struct ACPISDTHeader {
+  char Signature[4];
+  uint32_t Length;
+  uint8_t Revision;
+  uint8_t Checksum;
+  char OEMID[6];
+  char OEMTableID[8];
+  uint32_t OEMRevision;
+  uint32_t CreatorID;
+  uint32_t CreatorRevision;
+};
+
+struct FADT_t
+{
+    struct   ACPISDTHeader SDTHeader;
+    uint32_t FirmwareCtrl;
+    uint32_t Dsdt;
+
+    // field used in ACPI 1.0; no longer in use, for compatibility only
+    uint8_t  Reserved;
+
+    uint8_t  PreferredPowerManagementProfile;
+    uint16_t SCI_Interrupt;
+    uint32_t SMI_CommandPort;
+    uint8_t  AcpiEnable;
+    uint8_t  AcpiDisable;
+    uint8_t  S4BIOS_REQ;
+    uint8_t  PSTATE_Control;
+    uint32_t PM1aEventBlock;
+    uint32_t PM1bEventBlock;
+    uint32_t PM1aControlBlock;
+    uint32_t PM1bControlBlock;
+    uint32_t PM2ControlBlock;
+    uint32_t PMTimerBlock;
+    uint32_t GPE0Block;
+    uint32_t GPE1Block;
+    uint8_t  PM1EventLength;
+    uint8_t  PM1ControlLength;
+    uint8_t  PM2ControlLength;
+    uint8_t  PMTimerLength;
+    uint8_t  GPE0Length;
+    uint8_t  GPE1Length;
+    uint8_t  GPE1Base;
+    uint8_t  CStateControl;
+    uint16_t WorstC2Latency;
+    uint16_t WorstC3Latency;
+    uint16_t FlushSize;
+    uint16_t FlushStride;
+    uint8_t  DutyOffset;
+    uint8_t  DutyWidth;
+    uint8_t  DayAlarm;
+    uint8_t  MonthAlarm;
+    uint8_t  Century;
+
+    // reserved in ACPI 1.0; used since ACPI 2.0+
+    uint16_t BootArchitectureFlags;
+
+    uint8_t  Reserved2;
+    uint32_t Flags;
+
+    // 12 byte structure; see below for details
+    struct GenericAddr ResetReg;
+
+    uint8_t  ResetValue;
+    uint8_t  Reserved3[3];
+  
+    // 64bit pointers - Available on ACPI 2.0+
+    uint64_t                X_FirmwareControl;
+    uint64_t                X_Dsdt;
+
+    struct GenericAddr X_PM1aEventBlock;
+    struct GenericAddr X_PM1bEventBlock;
+    struct GenericAddr X_PM1aControlBlock;
+    struct GenericAddr X_PM1bControlBlock;
+    struct GenericAddr X_PM2ControlBlock;
+    struct GenericAddr X_PMTimerBlock;
+    struct GenericAddr X_GPE0Block;
+    struct GenericAddr X_GPE1Block;
+};
+
+struct RSDT_t {
+  struct ACPISDTHeader SDTHeader;
+  uint32_t PointerToOtherSDT[];
+};
+
+struct XSDT_t {
+  struct ACPISDTHeader SDTHeader;
+  uint64_t PointerToOtherSDT[];
+};
+
+typedef struct ACPIState {
+    struct RSDP_t* RSDP;
+    struct XSDP_t* XSDP;
+    struct RSDT_t* RSDT;
+    struct XSDT_t* XSDT;
+    struct FADT_t* FADT;
+    bool ValidPowerMGMTMode;
+    bool Initialized;
+} ACPIState;
+
+extern ACPIState ACPI;
+extern const char* PowerProfileStrings[8];
+
+Status ACPIInit(uint32_t InfoPtr);
+
+#endif //BOREALOS_ACPI_H

--- a/src/Core/Kernel.c
+++ b/src/Core/Kernel.c
@@ -6,10 +6,9 @@
 #include <Drivers/Graphics/Framebuffer.h>
 #include <Drivers/IO/FramebufferConsole.h>
 #include <Utility/Color.h>
-
 #include "Utility/StringFormatter.h"
-
 #include "Utility/Art.h"
+#include "Core/Firmware/ACPI.h"
 
 KernelState Kernel = {};
 
@@ -149,6 +148,14 @@ Status KernelInit(uint32_t InfoPtr) {
     Kernel.Printf("[== BorealOS %z.%z.%z ==]\n", BOREALOS_MAJOR_VERSION, BOREALOS_MINOR_VERSION, BOREALOS_PATCH_VERSION);
     LOG(LOG_INFO, "Serial initialized successfully.\n");
 
+    // Map the ACPI regions and initialize ACPI
+    if (ACPIInit(InfoPtr) != STATUS_SUCCESS) {
+        LOG(LOG_WARNING, "ACPI init failed!\n");
+    }
+    else {
+        LOG(LOG_INFO, "ACPI initialized.\n");
+    }
+
     // Now load the physical memory manager
     if (PhysicalMemoryManagerInit(InfoPtr) != STATUS_SUCCESS) {
         PANIC("Failed to initialize Physical Memory Manager!\n");
@@ -206,11 +213,5 @@ Status KernelInit(uint32_t InfoPtr) {
     }
 
     LOG(LOG_INFO, "Kernel Virtual Memory Manager initialized successfully.\n");
-
-    FramebufferConsoleWriteString(ART);
-    FramebufferConsoleWriteString(ART);
-    FramebufferConsoleWriteString(ART);
-
-
     return STATUS_SUCCESS;
 }

--- a/src/Definitions.h
+++ b/src/Definitions.h
@@ -52,6 +52,10 @@
 typedef enum {
     STATUS_SUCCESS = 0,
     STATUS_FAILURE = -1,
+    STATUS_UNSUPPORTED = -2,
+    STATUS_INVALID_PARAMETER = -3,
+    STATUS_OUT_OF_MEMORY = -4,
+    STATUS_TIMEOUT = -5,
 } Status;
 
 typedef enum {

--- a/src/Drivers/IO/FramebufferConsole.c
+++ b/src/Drivers/IO/FramebufferConsole.c
@@ -47,7 +47,7 @@ void FramebufferConsolePutChar(char c) {
         FramebufferConsole.CursorX++;
     }
 
-    if (FramebufferConsole.CursorX > FramebufferConsole.Width)
+    if (FramebufferConsole.CursorX >= FramebufferConsole.Width)
     {
         FramebufferConsole.CursorX = 0;
         MoveDown();

--- a/src/Utility/SerialOperations.h
+++ b/src/Utility/SerialOperations.h
@@ -7,9 +7,19 @@ static INLINE void outb(uint16_t port, uint8_t val) {
     ASM ("outb %0, %1" : : "a"(val), "Nd"(port));
 }
 
+static INLINE void outw(uint16_t port, uint16_t val) {
+    ASM ("outw %0, %1" : : "a"(val), "Nd"(port));
+}
+
 static INLINE uint8_t inb(uint16_t port) {
     uint8_t ret;
     ASM ("inb %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+static INLINE uint16_t inw(uint16_t port) {
+    uint16_t ret;
+    ASM ("inw %1, %0" : "=a"(ret) : "Nd"(port));
     return ret;
 }
 

--- a/src/Utility/StringTools.c
+++ b/src/Utility/StringTools.c
@@ -1,4 +1,4 @@
-#include "StringOps.h"
+#include "StringTools.h"
 
 int strncmp(const char* s1, const char* s2, size_t n) {
     for (size_t i = 0; i < n; i++) {

--- a/src/Utility/StringTools.c
+++ b/src/Utility/StringTools.c
@@ -1,0 +1,14 @@
+#include "StringOps.h"
+
+int strncmp(const char* s1, const char* s2, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c1 = (unsigned char)s1[i];
+        unsigned char c2 = (unsigned char)s2[i];
+
+        if (c1 != c2 || c1 == '\0' || c2 == '\0') {
+            return c1 - c2;
+        }
+    }
+    
+    return 0;
+}

--- a/src/Utility/StringTools.h
+++ b/src/Utility/StringTools.h
@@ -1,0 +1,7 @@
+#ifndef BOREALOS_STRINGTOOLS_H
+#define BOREALOS_STRINGTOOLS_H
+
+#include <Definitions.h>
+int strncmp(const char* s1, const char* s2, size_t n);
+
+#endif //BOREALOS_STRINGTOOLS_H


### PR DESCRIPTION
Core/Firmware/ACPI.h:
Core/Firmware/ACPI.c:
- Started basic ACPI stuff like finding the *SDP, *SDT, and FADT tables
- Added power management device-preferred profile discovery

Core/Kernel.c:
- ACPI is initialized

Drivers/IO/FramebufferConsole.c:
- Fixed a bug where the last character is cut off when text exceeds the console width (> to >= in width check)

Utility/SerialOperations.h:
- Added inw and outw definitions

Utility/StringTools.c:
Utility.StringTools.h:
- Added strncmp function