### PR TITLE
ATA & ATAPI

### DIFF
--- a/BochsCFG.bochs
+++ b/BochsCFG.bochs
@@ -13,7 +13,7 @@ ata0: enabled=true, ioaddr1=0x1f0, ioaddr2=0x3f0, irq=14
 ata0-master: type=cdrom, path="cmake-build-debug/BorealOS.iso", status=inserted, model="Generic 1234", biosdetect=auto
 ata0-slave: type=none
 ata1: enabled=true, ioaddr1=0x170, ioaddr2=0x370, irq=15
-ata1-master: type=none
+ata1-master: type=disk, path="HDD.img", cylinders=306, heads=4, spt=17, biosdetect=auto, model="Generic 1234"
 ata1-slave: type=none
 ata2: enabled=false
 ata3: enabled=false

--- a/TODO.md
+++ b/TODO.md
@@ -12,10 +12,10 @@ This is the tracker for features & bugs.
 - Framebuffer support
 - Text console
 - Virtual memory allocator
+- Basic ATA driver (read/write)
 
 ## Doing:
 
-- Basic ATA driver (read/write)
 
 ## To Do:
 
@@ -24,7 +24,6 @@ This is the tracker for features & bugs.
     - PS/2 (KB/Mouse) (andrew)
     - USB (HID, storage, etc) (m & andrew)
     - Storage Drivers
-      - ATA (PATA) (m)
       - AHCI (SATA) (andrew)
       - NVMe (m)
     - ACPI (andrew)

--- a/src/Core/Kernel.c
+++ b/src/Core/Kernel.c
@@ -7,6 +7,7 @@
 #include <Drivers/IO/FramebufferConsole.h>
 #include <Utility/Color.h>
 
+#include "Drivers/IO/Disk/ATA/ATACommon.h"
 #include "Utility/StringFormatter.h"
 
 #include "Utility/Art.h"
@@ -143,9 +144,7 @@ Status KernelInit(uint32_t InfoPtr) {
     if (FramebufferConsoleInit(KernelFramebuffer.Width / FONT_WIDTH, KernelFramebuffer.Height / FONT_HEIGHT, COLOR_LIGHTGRAY, OURBLE) != STATUS_SUCCESS) {
         PANIC("Failed to initialize Framebuffer Console!\n");
     }
-
-    FramebufferConsoleWriteString(ART);
-
+    
     Kernel.Printf("[== BorealOS %z.%z.%z ==]\n", BOREALOS_MAJOR_VERSION, BOREALOS_MINOR_VERSION, BOREALOS_PATCH_VERSION);
     LOG(LOG_INFO, "Serial initialized successfully.\n");
 
@@ -207,10 +206,10 @@ Status KernelInit(uint32_t InfoPtr) {
 
     LOG(LOG_INFO, "Kernel Virtual Memory Manager initialized successfully.\n");
 
-    FramebufferConsoleWriteString(ART);
-    FramebufferConsoleWriteString(ART);
-    FramebufferConsoleWriteString(ART);
-
+    // Initialize the ATA/ATAPI subsystem
+    if (ATAInit() != STATUS_SUCCESS) {
+        PANIC("Failed to initialize ATA/ATAPI subsystem!\n");
+    }
 
     return STATUS_SUCCESS;
 }

--- a/src/Core/Memory/Memory.c
+++ b/src/Core/Memory/Memory.c
@@ -51,3 +51,17 @@ void* memmove(void* destptr, const void* srcptr, size_t size) {
 
     return destptr;
 }
+
+int memcmp(const void *buf1, const void *buf2, size_t size) {
+    if (buf1 == buf2 || size == 0) return true;
+    const unsigned char* b1 = (const unsigned char*) buf1;
+    const unsigned char* b2 = (const unsigned char*) buf2;
+
+    for (size_t i = 0; i < size; i++) {
+        if (b1[i] != b2[i]) {
+            return (b1[i] < b2[i]) ? -1 : 1;
+        }
+    }
+
+    return 0;
+}

--- a/src/Core/Memory/Memory.h
+++ b/src/Core/Memory/Memory.h
@@ -12,4 +12,7 @@ void* memset(void* bufptr, int value, size_t size);
 /// Move a block of memory from source to destination, handling overlapping regions correctly.
 void* memmove(void* destptr, const void* srcptr, size_t size);
 
+/// Compare two blocks of memory. Returns the same as memcmp from libc (0 if equal, <0 if buf1<buf2, >0 if buf1>buf2).
+int memcmp(const void* buf1, const void* buf2, size_t size);
+
 #endif //BOREALOS_MEMORY_H

--- a/src/Definitions.h
+++ b/src/Definitions.h
@@ -52,6 +52,10 @@
 typedef enum {
     STATUS_SUCCESS = 0,
     STATUS_FAILURE = -1,
+    STATUS_UNSUPPORTED = -2,
+    STATUS_INVALID_PARAMETER = -3,
+    STATUS_OUT_OF_MEMORY = -4,
+    STATUS_TIMEOUT = -5,
 } Status;
 
 typedef enum {

--- a/src/Drivers/IO/Disk/ATA/ATA.c
+++ b/src/Drivers/IO/Disk/ATA/ATA.c
@@ -1,0 +1,188 @@
+#include "ATA.h"
+#include <Core/Kernel.h>
+#include "Utility/SerialOperations.h"
+#include "ATACommon.h"
+#include <Drivers/IO/Disk/Block.h>
+
+Status ReadSectors(uint32_t count, void *buffer, uint16_t ioBase) {
+    for (uint32_t sectorIdx = 0; sectorIdx < count; sectorIdx++) {
+        // Wait for DRQ for this sector
+        if (ATAPollStatus(ioBase, ATA_STATUS_DRQ, ATA_BSY_TIMEOUT) != STATUS_SUCCESS) {
+            LOG(LOG_ERROR, "Timeout waiting for DRQ after issuing read command.\n");
+            return STATUS_FAILURE;
+        }
+
+        // Read one sector (256 words)
+        for (int i = 0; i < ATA_SECTOR_SIZE / 2; i++) {
+            uint16_t data = inw(ioBase + ATA_REG_DATA);
+            ((uint16_t*)buffer)[sectorIdx * (ATA_SECTOR_SIZE / 2) + i] = data;
+        }
+    }
+
+    // Check for errors
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    if (status & ATA_STATUS_ERR) {
+        LOG(LOG_ERROR, "Error occurred during read operation.\n");
+        return STATUS_FAILURE;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+Status WriteSectors(uint32_t count, const void *buffer, uint16_t ioBase, bool lba48) {
+    for (uint32_t sectorIdx = 0; sectorIdx < count; sectorIdx++) {
+        // Wait for DRQ for this sector
+        if (ATAPollStatus(ioBase, ATA_STATUS_DRQ, ATA_BSY_TIMEOUT) != STATUS_SUCCESS) {
+            LOG(LOG_ERROR, "Timeout waiting for DRQ after issuing write command.\n");
+            return STATUS_FAILURE;
+        }
+
+        // Write one sector (256 words)
+        for (int i = 0; i < ATA_SECTOR_SIZE / 2; i++) {
+            uint16_t data = ((uint16_t*)buffer)[sectorIdx * (ATA_SECTOR_SIZE / 2) + i];
+            outw(ioBase + ATA_REG_DATA, data);
+        }
+
+        // Flush
+        outb(ioBase + ATA_REG_COMMAND, lba48 ? ATA_CMD_CACHE_FLUSH_EXT : ATA_CMD_CACHE_FLUSH);
+        ATAWait450ns(ioBase);
+    }
+
+    // Check for errors
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    if (status & ATA_STATUS_ERR) {
+        LOG(LOG_ERROR, "Error occurred during write operation.\n");
+        return STATUS_FAILURE;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+Status ATAReadSectors(BlockDevice* device, uint64_t sector, uint32_t count, void* buffer) {
+    if (device == nullptr || buffer == nullptr || count == 0) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    ATABlockDriverData* data = (ATABlockDriverData*)device->DriverData;
+    if (data == nullptr) {
+        return STATUS_FAILURE;
+    }
+
+    ATASelectDevice(device, data);
+    uint16_t ioBase = data->IOBase;
+
+    if (sector > 0x0FFFFFFF) {
+        LOG(LOG_ERROR, "LBA28 addressing only supported currently.\n");
+        return STATUS_UNSUPPORTED;
+    }
+
+    ATAPollStatus(ioBase, ATA_STATUS_BSY, ATA_BSY_TIMEOUT); // Wait for BSY to clear
+
+    // Set up registers for reading
+    ATASetCommandRegisters(ioBase, (uint32_t)sector, (uint8_t)count, data->Drive, ATA_CMD_READ_SECTORS);
+
+    return ReadSectors(count, buffer, ioBase);
+}
+
+Status ATAWriteSectors(BlockDevice* device, uint64_t sector, uint32_t count, const void* buffer) {
+    if (device == nullptr || buffer == nullptr || count == 0) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    ATABlockDriverData* data = (ATABlockDriverData*)device->DriverData;
+    if (data == nullptr) {
+        return STATUS_FAILURE;
+    }
+
+    if (data->Type == ATAPI_DRIVE) {
+        LOG(LOG_ERROR, "Attempted to write to an ATAPI device.\n");
+        return STATUS_UNSUPPORTED; // Writing to ATAPI devices is not supported
+    }
+
+    ATASelectDevice(device, data);
+    uint16_t ioBase = data->IOBase;
+
+    if (sector > 0x0FFFFFFF) {
+        LOG(LOG_ERROR, "LBA28 addressing only supported currently.\n");
+        return STATUS_UNSUPPORTED;
+    }
+
+    ATAPollStatus(ioBase, ATA_STATUS_BSY, ATA_BSY_TIMEOUT); // Wait for BSY to clear
+
+    // Set up registers for writing
+    ATASetCommandRegisters(ioBase, (uint32_t)sector, (uint8_t)count, data->Drive, ATA_CMD_WRITE_SECTORS);
+
+    return WriteSectors(count, buffer, ioBase, false);
+}
+
+
+Status ATAProbeDevice(uint16_t ioBase, uint8_t drive, ATABlockDriverData* blockDriverData, BlockDevice* outDevice)
+{
+    LOGF(LOG_DEBUG, "Probing %s drive on %s bus...\n",
+         (drive == 0) ? "master" : "slave",
+         (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary");
+
+    ATASelectDrive(ioBase, drive);
+
+    // Issue IDENTIFY DEVICE first (ATA)
+    outb(ioBase + ATA_REG_COMMAND, ATA_CMD_IDENTIFY);
+
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    if (status == 0) {
+        LOGF(LOG_DEBUG, "No device present at %s %s.\n",
+             (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+             (drive == 0) ? "master" : "slave");
+        return STATUS_FAILURE;
+    }
+
+    // Wait for BSY clear
+    uint32_t timeout = ATA_BSY_TIMEOUT;
+    while (status & ATA_STATUS_BSY) {
+        status = inb(ioBase + ATA_REG_STATUS);
+        if (--timeout == 0) {
+            LOGF(LOG_DEBUG, "Timeout waiting for %s %s.\n",
+                 (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+                 (drive == 0) ? "master" : "slave");
+            return STATUS_FAILURE;
+        }
+    }
+
+    uint16_t identifyData[256];
+    for (int i = 0; i < 256; i++) {
+        identifyData[i] = inw(ioBase + ATA_REG_DATA);
+    }
+
+    bool isHDD = false;
+    bool supportsLBA48 = false;
+    size_t totalSectors = 0;
+    ATAParseIdentify(identifyData, &isHDD, &supportsLBA48, &totalSectors);
+
+    if (!isHDD) {
+        LOGF(LOG_DEBUG, "Device at %s %s did not look like a hard disk.\n",
+             (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+             (drive == 0) ? "master" : "slave");
+        return STATUS_FAILURE;
+    }
+
+    LOGF(LOG_DEBUG, "Detected ATA hard disk at %s %s\n",
+         (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+         (drive == 0) ? "master" : "slave");
+    PRINTF("\t* Supports LBA48: %s\n", supportsLBA48 ? "Yes" : "No");
+    PRINTF("\t* Total Sectors: %u\n", (uint32_t)totalSectors);
+    PRINTF("\t* Total Size: %u MB\n", (uint32_t)((totalSectors * ATA_SECTOR_SIZE) / MiB));
+
+    // Fill out the BlockDevice structure
+    outDevice->SectorSize = ATA_SECTOR_SIZE;
+    outDevice->TotalSectors = totalSectors;
+    outDevice->DriverData = blockDriverData;
+    outDevice->Read = ATAReadSectors;
+    outDevice->Write = ATAWriteSectors;
+
+    blockDriverData->Bus = (ioBase == ATA_PRIMARY_BUS) ? ATA_BUS_PRIMARY : ATA_BUS_SECONDARY;
+    blockDriverData->Drive = (drive == 0) ? ATA_DRIVE_MASTER : ATA_DRIVE_SLAVE;
+    blockDriverData->IOBase = ioBase;
+    blockDriverData->ControlBase = (blockDriverData->Bus == ATA_BUS_PRIMARY) ? ATA_PRIMARY_CONTROL : ATA_SECONDARY_CONTROL;
+    blockDriverData->Type = ATA_DRIVE;
+
+    return STATUS_SUCCESS;
+}

--- a/src/Drivers/IO/Disk/ATA/ATA.h
+++ b/src/Drivers/IO/Disk/ATA/ATA.h
@@ -1,0 +1,10 @@
+#ifndef BOREALOS_ATA_H
+#define BOREALOS_ATA_H
+
+#include <Definitions.h>
+
+typedef struct ATABlockDriverData ATABlockDriverData; // Forward declaration to avoid circular dependency
+typedef struct BlockDevice BlockDevice;
+Status ATAProbeDevice(uint16_t ioBase, uint8_t drive, ATABlockDriverData* blockDriverData, BlockDevice* outDevice);
+
+#endif //BOREALOS_ATA_H

--- a/src/Drivers/IO/Disk/ATA/ATACommon.c
+++ b/src/Drivers/IO/Disk/ATA/ATACommon.c
@@ -1,0 +1,111 @@
+#include "ATACommon.h"
+#include "ATA.h"
+#include "ATAPI.h"
+
+#include <Core/Kernel.h>
+#include <Core/Memory/Memory.h>
+#include "Utility/SerialOperations.h"
+
+ATAState KernelATA = {};
+
+// The suggestion is to read the Status register FIFTEEN TIMES, and only pay attention to the value returned by the last one -- after selecting a new master or slave device. The point being that you can assume an IO port read takes at least 30ns, so doing the first fourteen creates a 420ns delay -- which allows the drive time to push the correct voltages onto the bus.
+void ATAWait450ns(uint16_t ioBase) {
+    for (int i = 0; i < 15; i++) {
+        inb(ioBase + ATA_REG_STATUS);
+    }
+}
+
+void ATASelectDrive(uint16_t ioBase, uint8_t drive) {
+    outb(ioBase + ATA_REG_HDDEVSEL, 0xA0 | (drive << 4));
+    ATAWait450ns(ioBase);
+}
+
+Status ATAPollStatus(uint16_t ioBase, uint8_t waitMask, uint32_t timeoutLimit) {
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    uint32_t timeout = timeoutLimit;
+    while ((status & waitMask) != waitMask) {
+        status = inb(ioBase + ATA_REG_STATUS);
+        if (--timeout == 0) return STATUS_TIMEOUT;
+    }
+    return STATUS_SUCCESS;
+}
+
+void ATASetCommandRegisters(uint16_t ioBase, uint32_t lba, uint8_t sectorCount, ATADrive drive, uint8_t command) {
+    outb(ioBase + ATA_REG_FEATURES, 0);
+    outb(ioBase + ATA_REG_SECCOUNT0, sectorCount);
+    outb(ioBase + ATA_REG_LBA0, (uint8_t)(lba & 0xFF));
+    outb(ioBase + ATA_REG_LBA1, (uint8_t)((lba >> 8) & 0xFF));
+    outb(ioBase + ATA_REG_LBA2, (uint8_t)((lba >> 16) & 0xFF));
+    outb(ioBase + ATA_REG_HDDEVSEL, 0xE0 | ((drive & 0x1) << 4) | ((lba >> 24) & 0x0F));
+    outb(ioBase + ATA_REG_COMMAND, command);
+    ATAWait450ns(ioBase);
+}
+
+void ATASelectDevice(BlockDevice *device, ATABlockDriverData *data) {
+    if (device != KernelATA.CurrentDevice || data->Bus != KernelATA.Bus || data->Drive != KernelATA.Drive) {
+        // Only reselect if necessary.
+        LOGF(LOG_DEBUG, "Selecting %s drive on %s bus...\n",
+             (data->Drive == ATA_DRIVE_MASTER) ? "master" : "slave",
+             (data->Bus == ATA_BUS_PRIMARY) ? "primary" : "secondary");
+
+        ATASelectDrive(data->IOBase, data->Drive);
+        KernelATA.CurrentDevice = device;
+        KernelATA.Bus = data->Bus;
+        KernelATA.Drive = data->Drive;
+    }
+}
+
+/*
+uint16_t 0: is useful if the device is not a hard disk.
+uint16_t 83: Bit 10 is set if the drive supports LBA48 mode.
+uint16_t 88: The bits in the low byte tell you the supported UDMA modes, the upper byte tells you which UDMA mode is active. If the active mode is not the highest supported mode, you may want to figure out why. Notes: The returned uint16_t should look like this in binary: 0000001 00000001. Each bit corresponds to a single mode. E.g. if the decimal number is 257, that means that only UDMA mode 1 is supported and running (the binary number above) if the binary number is 515, the binary looks like this, 00000010 00000011, that means that UDMA modes 1 and 2 are supported, and 2 is running. This is true for every mode. If it does not look like that, e.g 00000001 00000011, as stated above, you may want to find out why. The formula for finding out the decimal number is 257 * 2 ^ position + 2 ^position - 1.
+uint16_t 93 from a master drive on the bus: Bit 11 is supposed to be set if the drive detects an 80 conductor cable. Notes: if the bit is set then 80 conductor cable is present and UDMA modes > 2 can be used; if bit is clear then there may or may not be an 80 conductor cable and UDMA modes > 2 shouldn't be used but might work fine. Because this bit is "master device only", if there is a slave device and no master there is no way information about cable type (and would have to assume UDMA modes > 2 can't be used).
+uint16_t 60 & 61 taken as a uint32_t contain the total number of 28 bit LBA addressable sectors on the drive. (If non-zero, the drive supports LBA28.)
+uint16_t 100 through 103 taken as a uint64_t contain the total number of 48 bit addressable sectors on the drive. (Probably also proof that LBA48 is supported.)
+ */
+void ATAParseIdentify(uint16_t buffer[256], bool* isHDD, bool* supportsLBA48, size_t* totalSectors) {
+    // Check if it's an ATA device
+    if (buffer[0] == 0) {
+        *isHDD = false;
+        return;
+    }
+    *isHDD = true;
+
+    // Check if it supports LBA48
+    *supportsLBA48 = (buffer[83] & (1 << 10)) != 0;
+
+    // Get total sectors
+    if (*supportsLBA48) {
+        *totalSectors = ((uint64_t)buffer[103] << 48) | ((uint64_t)buffer[102] << 32) | ((uint64_t)buffer[101] << 16) | buffer[100];
+    } else {
+        *totalSectors = buffer[60] | ((uint32_t)buffer[61] << 16);
+    }
+}
+
+Status ATAInit(void) {
+    LOG(LOG_INFO, "Initializing ATA driver...\n");
+    uint16_t buses[2] = {ATA_PRIMARY_BUS, ATA_SECONDARY_BUS};
+
+    for (int busIndex = 0; busIndex < 2; busIndex++) {
+        uint16_t ioBase = buses[busIndex];
+
+        for (int drive = 0; drive < 2; drive++) {
+            if (ATAProbeDevice(ioBase, drive, &KernelATA.DeviceData[KernelATA.DeviceCount], &KernelATA.Devices[KernelATA.DeviceCount]) == STATUS_SUCCESS) {
+                // Successfully detected a device. Increment device count.
+                KernelATA.DeviceCount++;
+            }
+            else if (ATAPIProbeDevice(ioBase, drive, &KernelATA.DeviceData[KernelATA.DeviceCount], &KernelATA.Devices[KernelATA.DeviceCount]) == STATUS_SUCCESS) {
+                // Successfully detected an ATAPI device. Increment device count.
+                KernelATA.DeviceCount++;
+            }
+        }
+    }
+
+    if (KernelATA.DeviceCount == 0) {
+        LOG(LOG_WARNING, "No ATA drives detected.\n");
+    } else {
+        LOGF(LOG_INFO, "Total ATA drives detected: %d\n", KernelATA.DeviceCount);
+    }
+
+    return STATUS_SUCCESS;
+}

--- a/src/Drivers/IO/Disk/ATA/ATACommon.h
+++ b/src/Drivers/IO/Disk/ATA/ATACommon.h
@@ -1,0 +1,129 @@
+#ifndef BOREALOS_ATACOMMON_H
+#define BOREALOS_ATACOMMON_H
+
+// Thank you mr https://wiki.osdev.org/ATA_PIO_Mode
+
+#include <Definitions.h>
+#include <Core/Memory/VirtualMemoryManager.h>
+
+#include "../Block.h"
+
+#define ATA_MAX_DRIVES 4 // Support up to 4 ATA drives (2 channels, master/slave each)
+#define ATA_SECTOR_SIZE 512 // Standard sector size for ATA devices
+#define ATAPI_SECTOR_SIZE 2048 // Standard sector size for ATAPI devices (CD-ROMs)
+
+// ATA bus definitions
+#define ATA_PRIMARY_BUS 0x1F0 // Until 0x1F7 are the data and command ports
+#define ATA_PRIMARY_CONTROL 0x3F6 // Control port for primary bus
+#define ATA_SECONDARY_BUS 0x170 // Until 0x177 are the data and command ports
+#define ATA_SECONDARY_CONTROL 0x376 // Control port for secondary bus
+#define ATA_PRIMARY_IRQ 14
+#define ATA_SECONDARY_IRQ 15
+
+// ATA registers (I/O base + offset) (bits in parentheses are sizes, first is LBA28, second is LBA48)
+#define ATA_REG_DATA 0x00 // Data Register (16 bits)
+#define ATA_REG_ERROR 0x01 // Error Register (read) (8 bit/16 bits)
+#define ATA_REG_FEATURES 0x01 // Features Register (write) (8 bit/16 bits)
+#define ATA_REG_SECCOUNT0 0x02 // Sector Count Register 0 (read/write) (8 bit/16 bits)
+#define ATA_REG_LBA0 0x03 // LBA Low Register 0 (read/write) (8 bit/16 bits)
+#define ATA_REG_LBA1 0x04 // LBA Mid Register 1 (read/write) (8 bit/16 bits)
+#define ATA_REG_LBA2 0x05 // LBA High Register 2 (read/write) (8 bit/16 bits)
+#define ATA_REG_HDDEVSEL 0x06 // Drive/Head Register (8 bits)
+#define ATA_REG_COMMAND 0x07 // Command Register (write) (8 bits)
+#define ATA_REG_STATUS 0x07 // Status Register (read) (8 bits)
+
+// ATA registers (Control base + offset)
+#define ATA_REG_ALT_STATUS 0x00 // Alternate Status Register (read) (8 bits)
+#define ATA_REG_DEVICE_CONTROL 0x00 // Device Control Register (write) (8 bits)
+#define ATA_REG_DRIVE_ADDRESS 0x01 // Drive Address Register (read) (8 bits)
+
+// ATA error register bits
+#define ATA_ERR_AMNF 0x01 // Address mark not found
+#define ATA_ERR_TKZNF 0x02 // Track 0 not found
+#define ATA_ERR_ABRT 0x04 // Aborted command
+#define ATA_ERR_MCR 0x08 // Media change request
+#define ATA_ERR_IDNF 0x10 // ID not found
+#define ATA_ERR_MC 0x20 // Media changed
+#define ATA_ERR_UNC 0x40 // Uncorrectable data error
+#define ATA_ERR_BBK 0x80 // Bad block
+
+// ATA drive/head register bits
+#define ATA_DRIVE_HEAD_DRV 0x08 // Drive number (0 = master, 1 = slave)
+#define ATA_DRIVE_HEAD_LBA 0x40 // LBA mode (To check if LBA addressing is used)
+
+// ATA status flags (Status Register (I/O base + 7))
+#define ATA_STATUS_ERR 0x01 // Error
+#define ATA_STATUS_IDX 0x02 // Index (always 0)
+#define ATA_STATUS_CORR 0x04 // Corrected data
+#define ATA_STATUS_DRQ 0x08 // Data request
+#define ATA_STATUS_DSC 0x10 // Drive seek complete
+#define ATA_STATUS_DF 0x20 // Drive fault error (does not set ERR)
+#define ATA_STATUS_RDY 0x40 // Drive ready (DRDY)
+#define ATA_STATUS_BSY 0x80 // Busy
+
+// ATA device control register bits (Control Register (Control base + 0))
+#define ATA_CTRL_NIEN 0x02 // Disable interrupts when set
+#define ATA_CTRL_SRST 0x04 // Software reset
+#define ATA_CTRL_HOB 0x80 // High order byte (for LBA48)
+
+// ATA commands
+#define ATA_CMD_IDENTIFY 0xEC // Identify command
+#define ATA_CMD_IDENTIFY_PACKET_DEVICE 0xA1 // Identify Packet Device command
+#define ATA_CMD_READ_SECTORS 0x20 // Read sectors command (LBA28)
+#define ATA_CMD_READ_SECTORS_EXT 0x24 // Read sectors command (LBA48)
+#define ATA_CMD_READ_CAPACITY 0x25 // Read capacity command (LBA48)
+#define ATA_CMD_WRITE_SECTORS 0x30 // Write sectors command (LBA28)
+#define ATA_CMD_WRITE_SECTORS_EXT 0x34 // Write sectors command (LBA48)
+#define ATA_CMD_PACKET 0xA0 // Packet command
+#define ATA_CMD_DEVICE_RESET 0x08 // Device reset command
+#define ATA_CMD_CACHE_FLUSH 0xE7 // Cache flush command (LBA
+#define ATA_CMD_CACHE_FLUSH_EXT 0xEA // Cache flush command (LBA48)
+#define ATA_CMD_STANDBY_IMMEDIATE 0xE0 // Standby immediate command
+#define ATA_BSY_TIMEOUT 100000
+
+typedef enum {
+    ATA_BUS_PRIMARY,
+    ATA_BUS_SECONDARY
+} ATABus;
+
+typedef enum {
+    ATA_DRIVE_MASTER,
+    ATA_DRIVE_SLAVE
+} ATADrive;
+
+typedef enum {
+    ATA_DRIVE,
+    ATAPI_DRIVE
+} ATADriveType;
+
+typedef struct ATABlockDriverData {
+    ATABus Bus;
+    ATADrive Drive;
+    uint16_t IOBase; // I/O base port for the bus
+    uint16_t ControlBase; // Control base port for the bus
+    ATADriveType Type; // ATA or ATAPI
+} ATABlockDriverData;
+
+typedef struct ATAState {
+    ATABus Bus; // Primary or secondary bus, this is to know which ports to use.
+    ATADrive Drive; // Master or slave drive on the bus
+
+    BlockDevice Devices[ATA_MAX_DRIVES]; // Block devices for each detected ATA drive
+    ATABlockDriverData DeviceData[ATA_MAX_DRIVES]; // Driver-specific data for each device
+    BlockDevice *CurrentDevice; // Currently selected device for operations
+    uint8_t DeviceCount; // Number of detected ATA drives
+} ATAState;
+
+extern ATAState KernelATA;
+
+/// Initialize the ATA subsystem, detecting connected drives and setting up BlockDevice structures for them.
+Status ATAInit(void);
+
+void ATASelectDrive(uint16_t ioBase, uint8_t drive);
+void ATASelectDevice(BlockDevice *device, ATABlockDriverData *data);
+void ATAParseIdentify(uint16_t buffer[256], bool* isHDD, bool* supportsLBA48, size_t* totalSectors);
+void ATAWait450ns(uint16_t ioBase);
+Status ATAPollStatus(uint16_t ioBase, uint8_t mask, uint32_t timeout);
+void ATASetCommandRegisters(uint16_t ioBase, uint32_t lba, uint8_t sectorCount, ATADrive drive, uint8_t command);
+
+#endif //BOREALOS_ATACOMMON_H

--- a/src/Drivers/IO/Disk/ATA/ATAPI.c
+++ b/src/Drivers/IO/Disk/ATA/ATAPI.c
@@ -1,0 +1,165 @@
+#include "ATA.h"
+#include <Core/Kernel.h>
+#include "Utility/SerialOperations.h"
+#include "ATACommon.h"
+#include <Drivers/IO/Disk/Block.h>
+
+static Status ATAPISendPacket(uint16_t ioBase, const uint8_t packet[12], void* buffer, uint32_t size, bool read)
+{
+    // Wait until drive is ready (not busy)
+    if (ATAPollStatus(ioBase, ATA_STATUS_RDY, ATA_BSY_TIMEOUT) != STATUS_SUCCESS) {
+        return STATUS_TIMEOUT;
+    }
+
+    // Program expected transfer length
+    outb(ioBase + ATA_REG_FEATURES, 0);
+    outb(ioBase + ATA_REG_LBA1, (uint8_t)(size & 0xFF));
+    outb(ioBase + ATA_REG_LBA2, (uint8_t)((size >> 8) & 0xFF));
+
+    // Issue PACKET command
+    outb(ioBase + ATA_REG_COMMAND, ATA_CMD_PACKET);
+    ATAWait450ns(ioBase);
+
+    // Wait for DRQ so we can send the 12-byte packet
+    if (ATAPollStatus(ioBase, ATA_STATUS_DRQ, ATA_BSY_TIMEOUT) != STATUS_SUCCESS) {
+        return STATUS_TIMEOUT;
+    }
+
+    // Send the packet as 6 words (little-endian)
+    for (int i = 0; i < 6; i++) {
+        uint16_t word = packet[2*i] | (packet[2*i+1] << 8);
+        outw(ioBase + ATA_REG_DATA, word);
+    }
+
+    // Now wait for the device to enter the data phase
+    if (size > 0) {
+        if (ATAPollStatus(ioBase, ATA_STATUS_DRQ, ATA_BSY_TIMEOUT) != STATUS_SUCCESS) {
+            return STATUS_TIMEOUT;
+        }
+
+        if (read) {
+            for (uint32_t i = 0; i < size / 2; i++) {
+                ((uint16_t*)buffer)[i] = inw(ioBase + ATA_REG_DATA);
+            }
+        } else {
+            for (uint32_t i = 0; i < size / 2; i++) {
+                outw(ioBase + ATA_REG_DATA, ((uint16_t*)buffer)[i]);
+            }
+        }
+    }
+
+    // Final status check
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    if (status & ATA_STATUS_ERR) {
+        return STATUS_FAILURE;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static Status ATAPIReadCapacity(uint16_t ioBase, uint32_t* totalSectors, uint32_t* sectorSize) {
+    uint8_t packet[12] = {0};
+    packet[0] = ATA_CMD_READ_CAPACITY;
+
+    uint8_t buffer[8];
+    Status st = ATAPISendPacket(ioBase, packet, buffer, sizeof(buffer), true);
+    if (st != STATUS_SUCCESS) {
+        return st;
+    }
+
+    uint32_t lastLBA = (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | buffer[3];
+    uint32_t secSize = (buffer[4] << 24) | (buffer[5] << 16) | (buffer[6] << 8) | buffer[7];
+    *totalSectors = lastLBA + 1; // Last LBA is zero-based
+    *sectorSize = secSize;
+
+    return STATUS_SUCCESS;
+}
+
+Status ATAPIReadSectors(BlockDevice* device, uint64_t lba, uint32_t count, void* buffer) {
+    ATABlockDriverData* data = (ATABlockDriverData*)device->DriverData;
+    uint16_t ioBase = data->IOBase;
+
+    for (uint32_t sectorIdx = 0; sectorIdx < count; sectorIdx++) {
+        uint8_t packet[12] = {0};
+        packet[0] = 0x28; // READ (10)
+        packet[2] = (uint8_t)((lba >> 24) & 0xFF);
+        packet[3] = (uint8_t)((lba >> 16) & 0xFF);
+        packet[4] = (uint8_t)((lba >> 8) & 0xFF);
+        packet[5] = (uint8_t)(lba & 0xFF);
+        packet[8] = 1; // Transfer 1 block at a time
+
+        uint8_t* bufPtr = (uint8_t*)buffer + sectorIdx * device->SectorSize;
+        Status st = ATAPISendPacket(ioBase, packet, bufPtr, device->SectorSize, true);
+        if (st != STATUS_SUCCESS) {
+            return st;
+        }
+        lba++;
+    }
+    return STATUS_SUCCESS;
+}
+
+Status ATAPIProbeDevice(uint16_t ioBase, uint8_t drive, ATABlockDriverData* blockDriverData, BlockDevice* outDevice) {
+    LOGF(LOG_DEBUG, "Probing %s drive on %s bus...\n",
+         (drive == 0) ? "master" : "slave",
+         (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary");
+
+    ATASelectDrive(ioBase, drive);
+
+    outb(ioBase + ATA_REG_COMMAND, ATA_CMD_IDENTIFY_PACKET_DEVICE);
+    ATAWait450ns(ioBase);
+
+    uint8_t status = inb(ioBase + ATA_REG_STATUS);
+    if (status == 0) {
+        LOGF(LOG_DEBUG, "No device present at %s %s.\n",
+             (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+             (drive == 0) ? "master" : "slave");
+        return STATUS_FAILURE;
+    }
+
+    uint32_t timeout = ATA_BSY_TIMEOUT;
+    while (status & ATA_STATUS_BSY) {
+        status = inb(ioBase + ATA_REG_STATUS);
+        if (--timeout == 0) {
+            LOGF(LOG_DEBUG, "Timeout waiting for %s %s.\n",
+                 (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+                 (drive == 0) ? "master" : "slave");
+            return STATUS_FAILURE;
+        }
+    }
+
+    uint16_t identifyData[256];
+    for (int i = 0; i < 256; i++) {
+        identifyData[i] = inw(ioBase + ATA_REG_DATA);
+    }
+    (void)identifyData; // idk anymore im tired
+
+    uint32_t totalSectors;
+    uint32_t sectorSize;
+    if (ATAPIReadCapacity(ioBase, &totalSectors, &sectorSize) != STATUS_SUCCESS) {
+        // If READ CAPACITY fails, we can't use this device
+        LOGF(LOG_DEBUG, "READ CAPACITY failed on %s %s.\n",
+             (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+             (drive == 0) ? "master" : "slave");
+        return STATUS_FAILURE;
+    }
+
+    LOGF(LOG_DEBUG, "Detected ATAPI device at %s %s\n",
+         (ioBase == ATA_PRIMARY_BUS) ? "primary" : "secondary",
+         (drive == 0) ? "master" : "slave");
+    PRINTF("\t* Sector Size: %u\n", sectorSize);
+    PRINTF("\t* Total Sectors: %u\n", totalSectors);
+
+    outDevice->SectorSize = sectorSize;
+    outDevice->TotalSectors = totalSectors;
+    outDevice->DriverData = blockDriverData;
+    outDevice->Read = ATAPIReadSectors;
+    outDevice->Write = nullptr; // usually not supported
+
+    blockDriverData->Bus = (ioBase == ATA_PRIMARY_BUS) ? ATA_BUS_PRIMARY : ATA_BUS_SECONDARY;
+    blockDriverData->Drive = (drive == 0) ? ATA_DRIVE_MASTER : ATA_DRIVE_SLAVE;
+    blockDriverData->IOBase = ioBase;
+    blockDriverData->ControlBase = (blockDriverData->Bus == ATA_BUS_PRIMARY) ? ATA_PRIMARY_CONTROL : ATA_SECONDARY_CONTROL;
+    blockDriverData->Type = ATAPI_DRIVE;
+
+    return STATUS_SUCCESS;
+}

--- a/src/Drivers/IO/Disk/ATA/ATAPI.h
+++ b/src/Drivers/IO/Disk/ATA/ATAPI.h
@@ -1,0 +1,10 @@
+#ifndef BOREALOS_ATAPI_H
+#define BOREALOS_ATAPI_H
+
+#include <Definitions.h>
+
+typedef struct ATABlockDriverData ATABlockDriverData; // Forward declaration to avoid circular dependency
+typedef struct BlockDevice BlockDevice;
+Status ATAPIProbeDevice(uint16_t ioBase, uint8_t drive, ATABlockDriverData* blockDriverData, BlockDevice* outDevice);
+
+#endif //BOREALOS_ATAPI_H

--- a/src/Drivers/IO/Disk/Block.h
+++ b/src/Drivers/IO/Disk/Block.h
@@ -1,0 +1,33 @@
+#ifndef BOREALOS_BLOCK_H
+#define BOREALOS_BLOCK_H
+
+#include <Definitions.h>
+
+typedef struct BlockDevice BlockDevice;
+typedef Status (*BlockReadFn)(BlockDevice* device, uint64_t sector, uint32_t count, void* buffer);
+typedef Status (*BlockWriteFn)(BlockDevice* device, uint64_t sector, uint32_t count, const void* buffer);
+
+typedef void* BlockDriverData;
+
+/// Represents a block device, such as a hard drive or SSD.
+/// This is API agnostic; specific implementations will fill in the function pointers.
+/// You must also provide a pointer to the actual device when calling the read/write functions. This is to allow multiple devices to share the same function pointers.
+typedef struct BlockDevice{
+    uint32_t SectorSize; // Size of a sector in bytes (usually 512 or 4096)
+    uint64_t TotalSectors; // Total number of sectors on the device
+    BlockDriverData DriverData; // Pointer to driver-specific data, can be NULL
+
+    /// Read sectors from the device. Returns STATUS_SUCCESS on success, or an error code on failure.
+    /// The count is in sectors, not bytes.
+    /// The buffer must be large enough to hold count * SectorSize bytes.
+    /// If null, the device does not support reading.
+    BlockReadFn Read; // Function pointer to read sectors
+
+    /// Write sectors to the device. Returns STATUS_SUCCESS on success, or an error code on failure.
+    /// The count is in sectors, not bytes.
+    /// The buffer must be large enough to hold count * SectorSize bytes.
+    /// If null, the device does not support writing.
+    BlockWriteFn Write; // Function pointer to write sectors
+} BlockDevice;
+
+#endif //BOREALOS_BLOCK_H

--- a/src/Utility/SerialOperations.h
+++ b/src/Utility/SerialOperations.h
@@ -13,6 +13,16 @@ static INLINE uint8_t inb(uint16_t port) {
     return ret;
 }
 
+static INLINE uint16_t inw(uint16_t port) {
+    uint16_t ret;
+    ASM ("inw %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+static INLINE void outw(uint16_t port, uint16_t val) {
+    ASM ("outw %0, %1" : : "a"(val), "Nd"(port));
+}
+
 static INLINE void io_wait(void) {
     // This is a no-op, but it ensures that the I/O operations are completed
     ASM ("outb %%al, $0x80" : : "a"(0));


### PR DESCRIPTION
ATA and ATAPI support!
This PR also creates a generic BlockDevice, which other disk systems will also use.

The BlockDevice has a bit of metadata about the drive it represents, and a generic handle for internal driver use. The Read & Write functions can be used to... read and write... 

ATA & ATAPI is based on https://wiki.osdev.org/ATA_PIO_Mode and https://wiki.osdev.org/ATAPI

Also modified the bochscfg to include the HDD.img as an ATA disk

Also changed the readme to add who will be doing what!