### PR TITLE
Switch to flanterm for fbcon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,21 @@ target_link_options(BorealOS.elf PRIVATE
         -nostartfiles
 )
 
+# Get flanterm automatically
+include(FetchContent)
+FetchContent_Declare(
+        flanterm
+        GIT_REPOSITORY https://codeberg.org/Mintsuki/Flanterm.git
+        GIT_TAG v2.1.0
+)
+
+FetchContent_MakeAvailable(flanterm)
+
+file(GLOB_RECURSE FLANTERM_SOURCES ${flanterm_SOURCE_DIR}/src/*.c)
+
+target_sources(BorealOS.elf PRIVATE ${FLANTERM_SOURCES})
+target_include_directories(BorealOS.elf PRIVATE ${flanterm_SOURCE_DIR}/src)
+
 # Now we need to create the actual ISO.
 # First in the build directory, create a directory called "iso" and create the following directory structure:
 # boot/grub/fonts

--- a/src/Core/Memory/Memory.c
+++ b/src/Core/Memory/Memory.c
@@ -65,3 +65,18 @@ int memcmp(const void *buf1, const void *buf2, size_t size) {
 
     return 0;
 }
+
+void* memcpy(void *destptr, const void *srcptr, size_t size) {
+    if (destptr == srcptr || size == 0) return destptr;
+    unsigned char* dest = (unsigned char*) destptr;
+    const unsigned char* src = (const unsigned char*) srcptr;
+
+    ASM (
+        "rep movsb"
+        : "+D"(dest), "+S"(src), "+c"(size)
+        :
+        : "memory"
+    );
+
+    return destptr;
+}

--- a/src/Core/Memory/Memory.h
+++ b/src/Core/Memory/Memory.h
@@ -15,4 +15,7 @@ void* memmove(void* destptr, const void* srcptr, size_t size);
 /// Compare two blocks of memory. Returns the same as memcmp from libc (0 if equal, <0 if buf1<buf2, >0 if buf1>buf2).
 int memcmp(const void* buf1, const void* buf2, size_t size);
 
+/// Memory copy function. Copies 'size' bytes from 'srcptr' to 'destptr'.
+void* memcpy(void* destptr, const void* srcptr, size_t size);
+
 #endif //BOREALOS_MEMORY_H

--- a/src/Drivers/Graphics/Framebuffer.c
+++ b/src/Drivers/Graphics/Framebuffer.c
@@ -5,8 +5,7 @@
 #include <Drivers/CPU.h>
 #include <Utility/Drawing.h>
 #include <Utility/Color.h>
-
-#include "Core/Kernel.h"
+#include <Core/Kernel.h>
 
 FramebufferConfig KernelFramebuffer = {};
 
@@ -15,20 +14,20 @@ Status FramebufferInit(uint32_t InfoPtr)
     LOG(LOG_INFO, "Initializing framebuffer...\n");
 
     // Attempt to get the framebuffer information using multiboot2; if the request failed, return a failure status and don't try to init further
-    struct multiboot_tag_framebuffer_common* FBInfo = MBGetTag(InfoPtr, MULTIBOOT_TAG_TYPE_FRAMEBUFFER);
+    KernelFramebuffer.FBInfo = MBGetTag(InfoPtr, MULTIBOOT_TAG_TYPE_FRAMEBUFFER);
 
-    if (!FBInfo)
+    if (!KernelFramebuffer.FBInfo)
     {
         LOG(LOG_ERROR, "Failed to get framebuffer information from multiboot2!\n");
         return STATUS_FAILURE;
     }
 
     // Set up the framebuffer state struct using the values we got from the multiboot2 bootloader
-    KernelFramebuffer.BitDepth = FBInfo->framebuffer_bpp;
-    KernelFramebuffer.Address = (void*)((uint32_t)FBInfo->framebuffer_addr);
-    KernelFramebuffer.Height = FBInfo->framebuffer_height;
-    KernelFramebuffer.Width = FBInfo->framebuffer_width;
-    KernelFramebuffer.Pitch = FBInfo->framebuffer_pitch;
+    KernelFramebuffer.BitDepth = KernelFramebuffer.FBInfo->common.framebuffer_bpp;
+    KernelFramebuffer.Address = (void*)((uint32_t)KernelFramebuffer.FBInfo->common.framebuffer_addr);
+    KernelFramebuffer.Height = KernelFramebuffer.FBInfo->common.framebuffer_height;
+    KernelFramebuffer.Width = KernelFramebuffer.FBInfo->common.framebuffer_width;
+    KernelFramebuffer.Pitch = KernelFramebuffer.FBInfo->common.framebuffer_pitch;
     KernelFramebuffer.CanUse = true;
 
     // Print the framebuffer properties
@@ -59,29 +58,5 @@ void FramebufferMapSelf(PagingState *paging) {
         void *vAddr = (void *)((size_t)KernelFramebuffer.Address + (i * PMM_PAGE_SIZE));
         void *pAddr = (void *)ALIGN_DOWN((size_t)KernelFramebuffer.Address + (i * PMM_PAGE_SIZE), PMM_PAGE_SIZE);
         PagingMapPage(paging, vAddr, pAddr, true, false, fbCacheFlags);
-    }
-}
-
-void FramebufferShift(size_t lines, uint32_t fillColor) {
-    if (!KernelFramebuffer.CanUse || lines == 0)
-        return;
-
-    if (lines >= KernelFramebuffer.Height)
-        lines = KernelFramebuffer.Height;
-
-    size_t rowBytes = KernelFramebuffer.Pitch;
-    size_t copyBytes = (KernelFramebuffer.Height - lines) * rowBytes;
-
-    uint8_t* fb = (uint8_t*) KernelFramebuffer.Address;
-
-    // Shift framebuffer up
-    memmove(fb, fb + lines * rowBytes, copyBytes);
-
-    // Fill bottom region
-    for (size_t y = KernelFramebuffer.Height - lines; y < KernelFramebuffer.Height; y++) {
-        uint32_t* row = (uint32_t*)(fb + y * rowBytes);
-        for (size_t x = 0; x < KernelFramebuffer.Width; x++) {
-            row[x] = fillColor;
-        }
     }
 }

--- a/src/Drivers/Graphics/Framebuffer.h
+++ b/src/Drivers/Graphics/Framebuffer.h
@@ -5,6 +5,7 @@
 #include <Core/Memory/Paging.h>
 
 typedef struct FramebufferConfig {
+    struct multiboot_tag_framebuffer* FBInfo; // Multiboot2-provided information struct that describes the framebuffer
     uint32_t* Address; // Bitmap for tracking allocated pages
     size_t Width; // Width of the FB in pixels
     size_t Height; // Height of the FB in pixels
@@ -22,8 +23,5 @@ Status FramebufferInit(uint32_t InfoPtr);
 /// Map the framebuffer into the current paging context
 /// This is necessary to allow the kernel to access the framebuffer after enabling paging
 void FramebufferMapSelf(PagingState* paging);
-
-/// Shift the framebuffer content up by a number of lines, filling the new space with a specified color
-void FramebufferShift(size_t lines, uint32_t fillColor);
 
 #endif //BOREALOS_FRAMEBUFFER_H

--- a/src/Drivers/IO/FramebufferConsole.h
+++ b/src/Drivers/IO/FramebufferConsole.h
@@ -6,18 +6,15 @@
 #define FRAMEBUFFER_CONSOLE_TAB_SIZE 4
 
 typedef struct FramebufferConsoleState {
+    struct flanterm_context* TermContext; // The flanterm context
     size_t Width; // Width of the console in characters
     size_t Height; // Height of the console in characters
-    size_t CursorX; // Current cursor X position (in characters)
-    size_t CursorY; // Current cursor Y position (in characters)
-    uint32_t ForegroundColor; // Text color
-    uint32_t BackgroundColor; // Background color
+    bool CanUse; // Used to show when the console can be written to
 } FramebufferConsoleState;
 
 extern FramebufferConsoleState FramebufferConsole;
 
 Status FramebufferConsoleInit(size_t width, size_t height, uint32_t foregroundColor, uint32_t backgroundColor);
-void FramebufferConsolePutChar(char c);
 void FramebufferConsoleWriteString(const char* str);
 void FramebufferConsoleClear();
 

--- a/src/Utility/StringTools.c
+++ b/src/Utility/StringTools.c
@@ -1,4 +1,20 @@
 #include "StringTools.h"
+//#include <string.h>
+
+// Provided from https://wiki.osdev.org/Meaty_Skeleton, but I've added a length limit
+size_t strlen(const char* str) {
+	size_t len = 0;
+
+	while (str[len])
+    {
+        len++;
+
+        if (len > 4096)
+            return -1;
+    }
+
+	return len;
+}
 
 int strncmp(const char* s1, const char* s2, size_t n) {
     for (size_t i = 0; i < n; i++) {

--- a/src/Utility/StringTools.h
+++ b/src/Utility/StringTools.h
@@ -2,6 +2,7 @@
 #define BOREALOS_STRINGTOOLS_H
 
 #include <Definitions.h>
+size_t strlen(const char* str);
 int strncmp(const char* s1, const char* s2, size_t n);
 
 #endif //BOREALOS_STRINGTOOLS_H


### PR DESCRIPTION
This greatly improves speed, adds ANSI escape code support, and more.

CMakeLists.txt:
- Added automatic git fetch for flanterm

Core/Kernel.c:
- Changed color code to use ANSI escape codes instead of variable assignment
- Removed unused includes

Core/Memory/Memory.c:
Core/Memory/Memory.h:
- Added memcpy utility for flanterm

Drivers/Graphics/Framebuffer.c:
Drivers/Graphics/Framebuffer.h:
- fbconfig struct now contains the multiboot framebuffer struct
- Removed old and unused framebuffer functions

Drivers/IO/FramebufferConsole.c:
Drivers/IO/FramebufferConsole.h:
- Changed custom terminal implementation to fkanterm for greatly improved speed and compatibility
- Removed unused and old framebuffer functions
- fbcon state struct now contains the "CanUse" boolean, which is used to show when the console can be written to
- Changed console clear function to use the ANSI escape code for console clear, rather than clearing the screen and resetting cursor positions manually

Utility/StringTools.c:
Utility/StringTools.h:
- Added strlen function for flanterm