### PR TITLE
irqhandler

### DIFF
--- a/src/Core/Interrupts/IDT.c
+++ b/src/Core/Interrupts/IDT.c
@@ -44,8 +44,8 @@ IDTState KernelIDT = {};
 void irq_handler(uint8_t irq, RegisterState *regs) {
     (void)regs; // Unused parameter
     PICSendEOI(irq);
-    if (KernelIDT.IRQSet[irq - 0x20] && KernelIDT.ExceptionHandlers[irq - 0x20]) {
-        KernelIDT.ExceptionHandlers[irq - 0x20]((uint32_t)irq, regs);
+    if (KernelIDT.IRQSet[irq - 0x20] && KernelIDT.IRQHandlers[irq - 0x20]) {
+        KernelIDT.IRQHandlers[irq - 0x20]((uint32_t)irq, regs);
     }
 
     // It wasn't handled, that's fine, just don't do anything
@@ -137,4 +137,9 @@ void IDTSetEntry(uint8_t vector, void *isr, uint8_t flags) {
 
 void IDTSetExceptionHandler(uint8_t exceptionNumber, ExceptionHandlerFn handler) {
     KernelIDT.ExceptionHandlers[exceptionNumber] = handler;
+}
+
+void IDTSetIRQHandler(uint8_t irqNumber, IRQHandlerFn handler) {
+    KernelIDT.IRQSet[irqNumber] = true;
+    KernelIDT.IRQHandlers[irqNumber] = handler;
 }

--- a/src/Core/Interrupts/IDT.h
+++ b/src/Core/Interrupts/IDT.h
@@ -57,6 +57,7 @@ void IDTSetExceptionHandler(uint8_t exceptionNumber, ExceptionHandlerFn handler)
 
 /// Set a handler for a specific IRQ
 /// You must still enable the IRQ line in the PIC for it to be received
+/// This function must be called with the IRQ number (0-15), not the vector number (32-47)
 void IDTSetIRQHandler(uint8_t irqNumber, IRQHandlerFn handler);
 
 #endif //BOREALOS_IDT_H

--- a/src/Core/Interrupts/IDT.h
+++ b/src/Core/Interrupts/IDT.h
@@ -32,13 +32,15 @@ typedef struct {
 } PACKED IDTDescriptor;
 
 typedef void (*ExceptionHandlerFn)(uint32_t exceptionNumber, RegisterState* state);
+typedef void (*IRQHandlerFn)(uint8_t irqNumber, RegisterState* state);
 
 typedef struct IDTState {
     IDTDescriptor Descriptor;
     IDTEntry Entries[256];
     bool VectorSet[256];
     bool IRQSet[16];
-    ExceptionHandlerFn ExceptionHandlers[16]; // Handlers for CPU exceptions
+    ExceptionHandlerFn ExceptionHandlers[32]; // Handlers for CPU exceptions
+    IRQHandlerFn IRQHandlers[16]; // Handlers for IRQs
 } IDTState;
 
 extern IDTState KernelIDT;
@@ -52,5 +54,9 @@ void IDTSetEntry(uint8_t vector, void *isr, uint8_t flags);
 
 /// Set a handler for a specific CPU exception
 void IDTSetExceptionHandler(uint8_t exceptionNumber, ExceptionHandlerFn handler);
+
+/// Set a handler for a specific IRQ
+/// You must still enable the IRQ line in the PIC for it to be received
+void IDTSetIRQHandler(uint8_t irqNumber, IRQHandlerFn handler);
 
 #endif //BOREALOS_IDT_H


### PR DESCRIPTION
Increased exception handler count to 32 to match interrupts.S.

Added IRQHandlers. Use IDTSetIrqHandler to set an IRQ handler.