### PR TITLE
Create RTC & PIT timers.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ case $EMULATOR in
         ;;
     qemu)
         echo "Running in normal mode..."
-        qemu-system-i386 $FLAGS -no-shutdown -no-reboot -serial file:logs/serial.log -cpu qemu32,vendor=QEMU_VirtSys -smp 2 -d int,cpu_reset -m 128M -hda HDD.img -cdrom ./cmake-build-debug/BorealOS.iso -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0 -display gtk
+        qemu-system-i386 $FLAGS -no-shutdown -no-reboot -serial file:logs/serial.log -cpu qemu32,vendor=QEMU_VirtSys -smp 2 -d guest_errors,cpu_reset -m 128M -hda HDD.img -cdrom ./cmake-build-debug/BorealOS.iso -audiodev pa,id=snd0 -machine pcspk-audiodev=snd0 -display gtk
         ;;
     *)
         echo "No emulator specified. Use --Bochs or --QEMU."

--- a/src/Core/Interrupts/PIT.c
+++ b/src/Core/Interrupts/PIT.c
@@ -1,0 +1,68 @@
+#include "PIT.h"
+
+#include <Core/Interrupts/IDT.h>
+#include <Utility/SerialOperations.h>
+
+PITConfig KernelPITConfig = {
+    .Frequency = 0,
+    .Divisor = 0,
+    .IsInitialized = false
+};
+
+PITState KernelPIT = {
+    .Milliseconds = 0,
+    .Ticks = 0,
+    .TickTracker = 0,
+    .IsInitialized = false
+};
+
+void pit_interrupt(uint8_t irqNumber, RegisterState* state) {
+    (void)irqNumber, (void)state;
+    if (!KernelPIT.IsInitialized || !KernelPITConfig.IsInitialized) {
+        return; // PIT not initialized, ignore the interrupt
+    }
+    KernelPIT.Ticks++;
+    KernelPIT.TickTracker++;
+
+    if (KernelPIT.TickTracker >= KernelPITConfig.Frequency / 1000) {
+        KernelPIT.TickTracker = 0;
+        KernelPIT.Milliseconds++;
+    }
+
+    // The interrupt is automatically acknowledged by the PIC, so we don't need to do anything here
+}
+
+Status PITInit(uint32_t frequency) {
+    KernelPITConfig.Frequency = frequency;
+    KernelPITConfig.Divisor = PIT_FREQUENCY / frequency;
+    if (KernelPITConfig.Divisor < PIT_DIVISOR_MIN || KernelPITConfig.Divisor > PIT_DIVISOR_MAX) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    KernelPITConfig.TimeIntervalMicroseconds = 1000000 / frequency;
+    KernelPITConfig.IsInitialized = true;
+
+    ASM ("cli"); // Disable interrupts while we set up
+
+    // Set the PIT to mode 3 (square wave generator), binary mode, and access mode lobyte/hibyte
+    outb(PIT_COMMAND_REGISTER, PIT_CHANNEL_0 | PIT_LOWBYTE_HIBYTE | PIT_MODE3 | PIT_BINARY);
+    io_wait();
+    outb(PIT_CHANNEL_0, (uint8_t)(KernelPITConfig.Divisor & 0xFF)); // Send the low byte of the divisor
+    io_wait();
+    outb(PIT_CHANNEL_0, (uint8_t)((KernelPITConfig.Divisor >> 8) & 0xFF)); // Send the high byte of the divisor
+    io_wait();
+    IDTSetIRQHandler(PIT_IRQ, pit_interrupt);
+    PICClearIRQMask(PIT_IRQ); // Unmask the PIT IRQ line
+
+    KernelPIT.IsInitialized = true;
+
+    ASM ("sti"); // Re-enable interrupts
+    return STATUS_SUCCESS;
+}
+
+void PITBusyWaitMicroseconds(uint32_t microseconds) {
+    uint64_t start = KernelPIT.Ticks;
+    while ((KernelPIT.Ticks - start) * (1000000 / KernelPITConfig.Frequency) < microseconds) {
+        ASM("hlt");
+    }
+}

--- a/src/Core/Interrupts/PIT.h
+++ b/src/Core/Interrupts/PIT.h
@@ -1,0 +1,58 @@
+#ifndef BOREALOS_PIT_H
+#define BOREALOS_PIT_H
+
+#include <Definitions.h>
+
+// This header is for the Programmable Interval Timer (PIT), which is used for system timing and generating periodic interrupts.
+// This can be used for high precision tasks, unlike the RTC which is only for keeping track of time.
+
+#define PIT_IRQ 0
+
+#define PIT_CHANNEL_0 0x40 // Read/Write
+#define PIT_CHANNEL_1 0x41 // Read/Write
+#define PIT_CHANNEL_2 0x42 // Read/Write
+#define PIT_COMMAND_REGISTER 0x43 // Write-only
+
+#define PIT_LOWBYTE_HIBYTE 0x30 // Access mode: lobyte/hibyte
+#define PIT_MODE0 0x00 // Mode 0: Interrupt on terminal count
+#define PIT_MODE1 0x02 // Mode 1: Hardware re-triggerable one-shot
+#define PIT_MODE2 0x04 // Mode 2: Rate generator
+#define PIT_MODE3 0x06 // Mode 3: Square wave generator
+#define PIT_MODE4 0x08 // Mode 4: Software triggered strobe
+#define PIT_MODE5 0x0A // Mode 5: Hardware triggered strobe
+#define PIT_BINARY 0x00 // Binary mode
+#define PIT_BCD 0x01 // BCD mode (we won't use this)
+
+#define PIT_FREQUENCY 1193180 // The PIT runs at 1.193180 MHz
+
+// The least amount of time we can set the PIT to is approximately 0.838 microseconds (1 / 1,193,180 Hz)
+// The maximum amount of time we can set the PIT to is approximately 54.925 seconds (65536 / 1,193,180 Hz)
+#define PIT_DIVISOR_MIN 1
+#define PIT_DIVISOR_MAX 65536
+
+#define PIT_SECONDS_TO_MICROSECONDS(x) ((x) * 1000000)
+#define PIT_MILLISECONDS_TO_MICROSECONDS(x) ((x) * 1000)
+#define PIT_MICROSECONDS_TO_SECONDS(x) ((x) / 1000000)
+#define PIT_MICROSECONDS_TO_MILLISECONDS(x) ((x) / 1000)
+
+typedef struct PITConfig {
+    uint32_t Frequency; // Frequency in Hz
+    uint32_t TimeIntervalMicroseconds; // Time interval in microseconds
+    uint32_t Divisor; // Divisor value for the PIT
+    bool IsInitialized;
+} PITConfig;
+
+typedef struct PITState {
+    uint64_t Milliseconds; // Number of milliseconds since the PIT was initialized
+    uint64_t Ticks; // Number of ticks since the PIT was initialized
+    uint32_t TickTracker; // Number of ticks since the last millisecond increment
+    bool IsInitialized;
+} PITState;
+
+extern PITConfig KernelPITConfig;
+extern PITState KernelPIT;
+
+Status PITInit(uint32_t frequency);
+void PITBusyWaitMicroseconds(uint32_t microseconds);
+
+#endif //BOREALOS_PIT_H

--- a/src/Drivers/RTC.c
+++ b/src/Drivers/RTC.c
@@ -1,0 +1,163 @@
+#include "RTC.h"
+
+#include <Core/Interrupts/IDT.h>
+#include <Utility/SerialOperations.h>
+
+RTCTimeState KernelRTCTime = {
+    .Seconds = 0,
+    .Minutes = 0,
+    .Hours = 0,
+    .DayOfWeek = 0,
+    .DayOfMonth = 0,
+    .Month = 0,
+    .Year = 0,
+    .IsInitialized = false
+};
+
+void clear_rtc_interrupt() {
+    outb(RTC_PORT, RTC_REGISTER_C);
+    inb(RTC_DATA_PORT); // Reading register C clears the interrupt
+}
+
+bool is_leap_year(uint16_t year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+const uint8_t days_in_month[] = {
+    31, // January
+    28, // February (29 in leap years)
+    31, // March
+    30, // April
+    31, // May
+    30, // June
+    31, // July
+    31, // August
+    30, // September
+    31, // October
+    30, // November
+    31  // December
+};
+
+void increment_time(RTCTimeState * rtc_time_state) {
+    // Increment seconds
+    rtc_time_state->Seconds++;
+    if (rtc_time_state->Seconds >= 60) {
+        rtc_time_state->Seconds = 0;
+        rtc_time_state->Minutes++;
+        if (rtc_time_state->Minutes >= 60) {
+            rtc_time_state->Minutes = 0;
+            rtc_time_state->Hours++;
+            if (rtc_time_state->Hours >= 24) {
+                rtc_time_state->Hours = 0;
+                rtc_time_state->DayOfMonth++;
+
+                // God this is ugly but whatever
+                uint8_t month_days = days_in_month[rtc_time_state->Month - 1];
+                if (rtc_time_state->Month == 2 && is_leap_year(rtc_time_state->Year)) {
+                    month_days = 29; // February in a leap year
+                }
+                if (rtc_time_state->DayOfMonth > month_days) {
+                    rtc_time_state->DayOfMonth = 1;
+                    rtc_time_state->Month++;
+                    if (rtc_time_state->Month > 12) {
+                        rtc_time_state->Month = 1;
+                        rtc_time_state->Year++;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void rtc_interrupt(uint8_t vector, RegisterState* state) {
+    (void)vector, (void)state;
+    static uint32_t tick = 0;
+    tick++;
+    if (tick >= 1024) {
+        // Roughly every second (assuming default rate of 1024Hz)
+        tick = 0;
+        // Update the RTC time
+        increment_time(&KernelRTCTime);
+    }
+
+    clear_rtc_interrupt(); // Acknowledge the interrupt
+}
+
+static inline uint8_t cmos_read(uint8_t reg) {
+    outb(RTC_PORT, reg | RTC_DISABLE_NMI);
+    return inb(RTC_DATA_PORT);
+}
+
+static bool is_updating() {
+    outb(RTC_PORT, RTC_REGISTER_A | RTC_DISABLE_NMI);
+    return (inb(RTC_DATA_PORT) & RTC_UIP_FLAG) != 0; // Check the Update In Progress (UIP) flag
+}
+
+static uint8_t bcd_to_binary(uint8_t bcd) {
+    return ((bcd / 16) * 10) + (bcd & 0x0F);
+}
+
+void read_rtc_time(uint8_t *sec, uint8_t *min, uint8_t *hour, uint8_t *day, uint8_t *month, uint16_t *year) {
+    uint8_t sec_raw = cmos_read(RTC_TIME_SECONDS);
+    uint8_t min_raw = cmos_read(RTC_TIME_MINUTES);
+    uint8_t hour_raw = cmos_read(RTC_TIME_HOURS);
+    uint8_t day_raw = cmos_read(RTC_DAY_OF_MONTH);
+    uint8_t month_raw = cmos_read(RTC_MONTH);
+    uint8_t year_raw = cmos_read(RTC_YEAR);
+    uint16_t century = RTC_CURRENT_CENTURY; // just change this every 100 years, if you even use this OS in 21XX
+    uint8_t register_b = cmos_read(RTC_REGISTER_B);
+
+    if (!(register_b & RTC_BCD_FLAG)) {
+        // Convert BCD to binary if necessary
+        sec_raw = bcd_to_binary(sec_raw);
+        min_raw = bcd_to_binary(min_raw);
+        hour_raw = bcd_to_binary(hour_raw & 0x7F); // Mask out the 12/24 hour flag
+        day_raw = bcd_to_binary(day_raw);
+        month_raw = bcd_to_binary(month_raw);
+        year_raw = bcd_to_binary(year_raw);
+    }
+
+    if (!(register_b & RTC_24H_FLAG) && (hour_raw & 0x80)) {
+        // Convert 12-hour format to 24-hour format
+        hour_raw = ((hour_raw & 0x7F) + 12) % 24;
+    }
+
+    *sec = sec_raw;
+    *min = min_raw;
+    *hour = hour_raw;
+    *day = day_raw;
+    *month = month_raw;
+    *year = year_raw + century;
+}
+
+Status RTCInit() {
+    IDTSetIRQHandler(RTC_IRQ, rtc_interrupt);
+
+    // Disable interrupts while we configure the RTC
+    ASM ("cli");
+
+    while (is_updating()){} // Wait until an update is not in progress
+
+    read_rtc_time(
+        &KernelRTCTime.Seconds,
+        &KernelRTCTime.Minutes,
+        &KernelRTCTime.Hours,
+        &KernelRTCTime.DayOfMonth,
+        &KernelRTCTime.Month,
+        &KernelRTCTime.Year
+    );
+
+    // Enable periodic interrupts
+    outb(RTC_PORT, RTC_REGISTER_B | RTC_DISABLE_NMI);
+    uint8_t prev = inb(RTC_DATA_PORT);
+    outb(RTC_PORT, RTC_REGISTER_B | RTC_DISABLE_NMI);
+    outb(RTC_DATA_PORT, prev | RTC_ENABLE_IRQS); // Set the IRQ enable bit
+    clear_rtc_interrupt();
+    // We are fine with the default rate of 1024Hz, because we don't use them for anything critical.
+    // We only use them to keep the RTC time updated, and not for precise timing.
+    // For anything critical we use the PIT or HPET timers.
+
+    ASM ("sti");
+
+    return STATUS_SUCCESS;
+}

--- a/src/Drivers/RTC.h
+++ b/src/Drivers/RTC.h
@@ -1,0 +1,45 @@
+#ifndef BOREALOS_RTC_H
+#define BOREALOS_RTC_H
+
+#include <Definitions.h>
+
+#define RTC_IRQ 8
+
+#define RTC_PORT 0x70
+#define RTC_DATA_PORT 0x71
+
+#define RTC_REGISTER_A 0x0A
+#define RTC_REGISTER_B 0x0B
+#define RTC_REGISTER_C 0x0C
+
+#define RTC_TIME_SECONDS 0x00
+#define RTC_TIME_MINUTES 0x02
+#define RTC_TIME_HOURS 0x04
+#define RTC_DAY_OF_MONTH 0x07
+#define RTC_MONTH 0x08
+#define RTC_YEAR 0x09
+#define RTC_CURRENT_CENTURY 2000 // just change this every 100 years
+
+#define RTC_DISABLE_NMI 0x80
+#define RTC_ENABLE_NMI 0x7F
+#define RTC_ENABLE_IRQS 0x40
+#define RTC_UIP_FLAG 0x80
+#define RTC_BCD_FLAG 0x04
+#define RTC_24H_FLAG 0x02 // 24-hour mode if set, 12-hour mode if clear (i hate am/pm we WILL use 24-hour mode)
+
+typedef struct RTCTimeState {
+    uint8_t Seconds; // 0-59
+    uint8_t Minutes; // 0-59
+    uint8_t Hours; // 0-23
+    uint8_t DayOfWeek; // 1-7
+    uint8_t DayOfMonth; // 1-31
+    uint8_t Month; // 1-12
+    uint16_t Year; // Full year (up to the limit of uint16_t)
+    bool IsInitialized;
+} RTCTimeState;
+
+extern RTCTimeState KernelRTCTime;
+
+Status RTCInit();
+
+#endif //BOREALOS_RTC_H


### PR DESCRIPTION
RTC.c/h:
Create the RTC subsystem based on the OSDev wiki page. This is an inaccurate system, do not use it for important things (scheduling, sleeping, stuff like that)

PIT.c/h:
Create the PIT subsystem based on the OSDev wiki page. This is accurate, and can be used for important things. Currently there's a "demo" busy wait function, which halts until a given period is over. This function halts everything.

Kernel.c:
Add subsystem inits.

run.sh:
Remove -d int and set to -d guest_errors. This prevents A LOT of logging when busy waiting using the PIT.