### PR TITLE
vfs

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,5 +3,10 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/deps/Limine" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/deps/mlibc-borealos" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/deps/mlibc-borealos/subprojects/freestnd-c-hdrs" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/deps/mlibc-borealos/subprojects/freestnd-cxx-hdrs" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/deps/mlibc-borealos/subprojects/frigg" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/deps/mlibc-borealos/subprojects/libsmarter" vcs="Git" />
   </component>
 </project>

--- a/docs/VFS.md
+++ b/docs/VFS.md
@@ -1,0 +1,186 @@
+BorealOS VFS specification 0.1 (first draft)
+## Overview
+The BorealOS VFS unifies multiple file systems under a single namespace. File systems are mounted under a named prefix. Each mount point can be accessed using `identifier:/path/to/file` where everything after the `:/` is the path on that file system.
+
+#### Examples
+
+- `initramfs:/` - the system's initial ram file system
+- `system:/` - virtual system information filesystem
+- `root:/` - the root partition
+- `usb:/` - a mounted USB
+
+## Path Syntax
+
+A fully qualified VFS path has the the form:
+```
+<identifier>:/<path>
+```
+Where `<identifier>` is one or more characters (128 character limit, `[_a-zA-Z0-9]{1,128}`), and `<path>` a POSIX style path.
+
+#### Rules
+
+- Path separator is `/`
+- `.` is the current directory
+- `..` is the parent directory (if escaping the mount, it throws an error: `root:/../../`)
+- Identifiers are case insensitive, while paths are case sensitive (depending on the underlying filesystem)
+- A trailing `/` is ignored
+- Consecutive `/` are collapsed (`root://some//file` becomes `root:/some/file`)
+
+Relative paths (without `<identifier>:/`) are resolved against the current working directory of the calling process, which must be a fully qualified path.
+
+## Mount System
+
+Mounting is done through a config file.
+A few mounts are always available, regardless of config.
+Mounts are parsed linearly, and `system:/` is always available, to find block devices.
+#### Config
+
+Each new mount config must be separated by a newline, and each entry must follow the following syntax:
+```
+# This is a comment
+mount <source> <target> [options] # this too
+```
+
+Where `<source>` is a VFS path, `<target>` is the mount point with the `:/` suffix, and options key value pairs using `key` or `key=value` syntax, separated by a space. Options can not have spaces in their value.
+
+For example:
+```
+mount system:/devices/disks/sda1 root:/
+mount system:/devices/disks/sda2 movies:/ noexec readonly 
+```
+
+The `root:/` prefix is expected to be there, if it is not available the system will not be able to function.
+
+`<target>` must be unique, if the `<target>` collides with something, it tries to append a number like `<target>0`, and increments the number until no collision is found.
+#### Options
+
+The available options are:
+- `readonly` - mounts the filesystem as readonly. Writes will fail.
+- `noexec` - prevents execution of binaries on this mount.
+- `sync` - writes are forced to be synchronous.
+- `nocollide` - if the `<target>` collides, do not mount
+- `required` - if the fs could not be mounted, error (produce a panic), if combined with `nocollide` produces a panic as well.
+
+#### Mount Table
+
+Under `system:/mounts/` there is a list of files where each entry corresponds to the `<identifier>:/` of a mount point. Each file contains information about the mount point.
+
+Schema:
+```
+identifier = "root"
+source = "<source>"
+target = "root:/"
+filesystem = "ext4"
+options = ["readonly"]
+mountedAt = 123 # unix timestamp
+```
+
+## `system:/` Filesystem
+
+BorealOS exposes system information through the read-only mounted "system:/" virtual file system.
+Information is exposed through files and folders, where each file has information exposed through the [TOML](https://toml.io/en/).
+
+The default structure looks like:
+```
+system:/
+	mounts/
+		system
+		initramfs
+		temp
+		user
+		config
+		usb
+		xyz
+		
+	devices/
+		disks/
+			<id> # one file per block device
+			<id>.partitions/ # if the device has partitions
+				<partition0>
+				<partition1>
+			
+		pci/
+			<domain>:<bus>:<slot>.<func>/
+				info
+		
+		cpu
+		memory
+		
+	kernel/
+		info
+		cmdline
+		modules/
+			<name>
+		
+	processes/
+		<pid>/
+			info
+			threads/
+				<tid>/
+			fds/
+				<fd>
+	
+```
+
+Where `cpu` would be something like:
+```
+count = 8
+physicalCount = 4
+processorName = "example processor"
+vendorID = "example vendor"
+features = ["sse", "avx2"]
+baseClock = 3141 # (in mhz)
+maxClock = 4600
+```
+
+The schemas for the other `system:/` components are TBD.
+
+## Permissions
+The VFS uses a unix like permission system, with UID, GID, and mode bits.
+When the VFS encounters an operation that requires permissions, it asks the underlying FS to provide the permissions.
+
+The FS implementer must decide what to do, when implementing the permission check function. If the FS does not support unix permissions (like FAT) it must decide on something.
+
+The default approach should be read/write, unless otherwise necessary.
+
+## Misc
+
+The BorealOS VFS does not yet support symlinks, or hardlinks. This will be looked at later.
+
+These are virtual file systems that provide other utilities.
+
+#### `initramfs:/`
+A read-only boot filesystem for loading modules & other stuff necessary for boot.
+Unmounted after boot. Still reserved.
+
+#### `temp:/`
+A volatile memory backed temp folder, resets every boot.
+
+#### `user:/`
+Dynamically maps to the user's directory, would route to `root:/users/admin` for example, if the user is admin. This is based on the process's user ID.
+
+#### `config:/`
+System wide config files, these are read/write files stored in the `root:/system/config/`
+
+## Errors
+
+Out of bounds traversal (think `root:/../../../some/file`, checked per segment) returns `FS_OUT_OF_MOUNT`
+
+Writing to a read only filesystem (like `system:/`) produces a FS_WRITE_PERMISSION error
+
+#### List of errors
+- `FS_SUCCESS` - 0, success!
+- `FS_WRITE_PERMISSION` - 1, no write permission
+- `FS_READ_PERMISSION` - 2, no read permission
+- `FS_MISSING_MOUNT` - 3, no mount at provided identifier
+- `FS_MISSING_ENTRY` - 4, no folder or file at provided path
+- `FS_EXEC_PERMISSION` - 5, no exec permission
+- `FS_OUT_OF_MOUNT` - 6, out of mount scope
+- `FS_NOT_A_DIRECTORY` - 7, expected a directory but found a file
+- `FS_ALREADY_EXISTS` - 8, file or folder already exists at path
+- `FS_INVALID_PATH` - 9, path is invalid
+- `FS_UNSUPPORTED` - 10, operation is unsupported by the underlying FS
+- `FS_INVALID_DESCRIPTOR` - 11, file descriptor is invalid
+
+These errors are returned as the function return code. (or syscall)
+

--- a/src/kernel/Include/FileSystemInterface.h
+++ b/src/kernel/Include/FileSystemInterface.h
@@ -3,9 +3,102 @@
 
 #include <Definitions.h>
 #include "Allocator.h"
+#include "Utility/HashMap.h"
+#include "Utility/String.h"
+#include "Utility/StringView.h"
+
+// Mode bits (same as in uapi/linux/stat.h):
+
+#define S_IFMT 0017000 // bitmask for the file type bitfields
+#define S_IFSOCK 0140000 // socket
+#define S_IFLNK 0120000 // symbolic link (unsupported in BorealOS, but we include it for completeness)
+#define S_IFREG 0100000 // regular file
+#define S_IFBLK 0060000 // block device
+#define S_IFDIR 0040000 // directory
+#define S_IFCHR 0020000 // character device
+#define S_IFIFO 0010000 // FIFO
+#define S_ISUID 0004000 // set-user-ID bit
+#define S_ISGID 0002000 // set-group-ID bit
+#define S_ISVTX 0001000 // sticky bit
+
+// Permission bits:
+#define S_IRWXU 0000700 // owner has read, write, and execute permission
+#define S_IRUSR 0000400 // owner has read permission
+#define S_IWUSR 0000200 // owner has write permission
+#define S_IXUSR 0000100 // owner has execute permission
+
+#define S_IRWXG 0000070 // group has read, write, and execute permission
+#define S_IRGRP 0000040 // group has read permission
+#define S_IWGRP 0000020 // group has write permission
+#define S_IXGRP 0000010 // group has execute permission
+
+#define S_IRWXO 0000007 // others have read, write, and execute permission
+#define S_IROTH 0000004 // others have read permission
+#define S_IWOTH 0000002 // others have write permission
+#define S_IXOTH 0000001 // others have execute permission
+
 
 /// Abstract interface for a file system.
 namespace FileSystem {
+    enum class FSResult : uint32_t {
+        SUCCESS = 0,
+
+        WRITE_PERMISSION = 1, // No write permission for the file
+        READ_PERMISSION = 2, // No read permission for the file
+        MISSING_MOUNT = 3, // No file system mounted for the given prefix
+        MISSING_ENTRY = 4, // The specified file or directory does not exist in the file system
+        EXEC_PERMISSION = 5, // No execute permission for the file
+        OUT_OF_MOUNT = 6, // The specified path tried to access outside the mounted file system (e.g. "partition_a:/../other_partition/file.txt")
+        NOT_A_DIRECTORY = 7, // Tried to access a file as a directory
+        ALREADY_EXISTS = 8, // Tried to create a file or directory that already exists
+        INVALID_PATH = 9, // The format of the path is invalid
+        UNSUPPORTED = 10, // The requested operation is not supported by this file system (e.g. writing to a read-only file system)
+        INVALID_DESCRIPTOR = 11, // The provided file descriptor is not valid
+
+        UNKNOWN = uint32_t(-1) // An unknown error occurred
+    };
+
+    enum class OpenFlags : uint32_t {
+        None = 0,
+        Read = 1 << 0, // Open the file for reading
+        Write = 1 << 1, // Open the file for writing
+        Create = 1 << 2, // Create the file if it doesn't exist (implies Write)
+        Truncate = 1 << 3, // Truncate the file to zero length if it already exists (implies Write)
+        Append = 1 << 4, // Move the file offset to the end of the file before each write (implies Write)
+    };
+
+    static OpenFlags operator| (OpenFlags a, OpenFlags b) {
+        return static_cast<OpenFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+    }
+
+    static OpenFlags operator& (OpenFlags a, OpenFlags b) {
+        return static_cast<OpenFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+    }
+
+    enum class MountFlags : uint32_t {
+        NONE = 0,
+        READ_ONLY = 1 << 0,
+        NO_EXEC = 1 << 1,
+        SYNC = 1 << 2,
+    };
+
+    static MountFlags operator| (MountFlags a, MountFlags b) {
+        return static_cast<MountFlags>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+    }
+
+    static MountFlags operator& (MountFlags a, MountFlags b) {
+        return static_cast<MountFlags>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+    }
+
+    enum class FileMode : uint32_t {
+        File = S_IFREG,
+        Directory = S_IFDIR,
+        CharacterDevice = S_IFCHR,
+        BlockDevice = S_IFBLK,
+        FIFO = S_IFIFO,
+        Socket = S_IFSOCK,
+    };
+
     class FileSystemInterface;
 
     struct File; // Opaque file struct, the actual definition is up to the implementation of the FileSystem.
@@ -13,11 +106,14 @@ namespace FileSystem {
         File* file; // The file that this descriptor refers to.
         FileSystemInterface* fs; // The file system that this descriptor belongs to, used to perform operations on the file.
         size_t offset; // The current offset in the file for read/write operations.
+        OpenFlags flags;
     };
 
     struct FileInfo {
         size_t size = 0; // The size of the file in bytes.
-        bool isDirectory = false; // Whether the file is a directory or not.
+        uint32_t mode = 0;
+        uint32_t ownerUserId = 0; // The user ID of the owner of the file.
+        uint32_t ownerGroupId = 0; // The group ID of the owner of the file.
     };
 
     struct Capabilities {
@@ -39,28 +135,123 @@ namespace FileSystem {
         [[nodiscard]] virtual Capabilities GetCapabilities() const = 0;
 
         /// Opens a file at the given path and returns a pointer to a File struct representing it, or nullptr if the file doesn't exist or couldn't be opened.
-        [[nodiscard]] virtual File* Open(const char* path) = 0;
+        [[nodiscard]] virtual FSResult Open(Utility::StringView path, OpenFlags flags, File **outFile, FileMode mode = FileMode::File) = 0;
 
         /// Reads up to size bytes from the given file into the provided buffer, and returns the number of bytes actually read, or -1 if there was an error.
-        virtual size_t Read(File* file, void* buffer, size_t size) = 0;
+        virtual FSResult Read(File* file, void* buffer, size_t size, size_t offset, size_t *outReadBytes) = 0;
 
         /// Writes size bytes from the provided buffer to the given file, and returns the number of bytes actually written, or -1 if there was an error.
-        virtual size_t Write(File* file, const void* buffer, size_t size) = 0;
+        virtual FSResult Write(File* file, const void* buffer, size_t size, size_t offset, size_t *outWrittenBytes) = 0;
 
         /// Returns information about the given file, such as its size and whether it's a directory. Returns true on success, or false if there was an error.
-        virtual bool GetFileInfo(File* file, FileInfo* info) = 0;
+        virtual FSResult GetFileInfo(File *file, FileInfo *info) = 0;
 
         /// If the given file is a directory, fills the provided DirectoryInfo struct with information about the directory.
-        virtual bool GetDirectoryInfo(File* file, DirectoryInfo* info) = 0;
+        virtual FSResult GetDirectoryInfo(File *file, DirectoryInfo *info) = 0;
 
         /// Frees any resources associated with the given DirectoryInfo struct, such as the entries array.
         virtual void FreeDirectoryInfo(DirectoryInfo* info) = 0;
 
         /// Closes the given file and releases any resources associated with it.
-        virtual void Close(File* file) = 0;
+        virtual FSResult Close(File *file) = 0;
+
+        // QoL functions that crash the kernel on error.
+        File* OpenOrPanic(Utility::StringView path) {
+            File* file = nullptr;
+            auto result = Open(path, OpenFlags::Read | OpenFlags::Write, &file);
+            if (result != FSResult::SUCCESS) {
+                LOG_ERROR("Failed to open file \"%s\". Error code: %u32", path.ToString().CStr(), static_cast<uint32_t>(result));
+                PANIC("Failed to open file.");
+            }
+
+            return file;
+        }
+
+        size_t ReadOrPanic(File* file, void* buffer, size_t size) {
+            size_t bytesRead = 0;
+            auto result = Read(file, buffer, size, 0, &bytesRead);
+            if (result != FSResult::SUCCESS) {
+                LOG_ERROR("Failed to read from file. Error code: %u32", static_cast<uint32_t>(result));
+                PANIC("Failed to read from file.");
+            }
+
+            return bytesRead;
+        }
+
+        size_t WriteOrPanic(File* file, const void* buffer, size_t size) {
+            size_t bytesWritten = 0;
+            auto result = Write(file, buffer, size, 0, &bytesWritten);
+            if (result != FSResult::SUCCESS) {
+                LOG_ERROR("Failed to write to file. Error code: %u32", static_cast<uint32_t>(result));
+                PANIC("Failed to write to file.");
+            }
+
+            return bytesWritten;
+        }
+
+        FileInfo GetFileInfoOrPanic(File* file) {
+            FileInfo info = {};
+            auto result = GetFileInfo(file, &info);
+            if (result != FSResult::SUCCESS) {
+                LOG_ERROR("Failed to get file info. Error code: %u32", static_cast<uint32_t>(result));
+                PANIC("Failed to get file info.");
+            }
+
+            return info;
+        }
+
+        DirectoryInfo GetDirectoryInfoOrPanic(File* file) {
+            DirectoryInfo info = {};
+            auto result = GetDirectoryInfo(file, &info);
+            if (result != FSResult::SUCCESS) {
+                LOG_ERROR("Failed to get directory info. Error code: %u32", static_cast<uint32_t>(result));
+                PANIC("Failed to get directory info.");
+            }
+
+            return info;
+        }
 
     protected:
         Allocator *_allocator;
+    };
+
+    // The VFS acts as a collection of mounted file systems, and is responsible for routing file operations to the correct file system based on the file path. It also provides a unified interface for performing file operations across all mounted file systems.
+    // The VFS uses a Windows like path system, where disks are represented by a prefix, like "partition_a", or "ramfs".
+    // You can access them using paths like "partition_a:/path/to/file" or "ramfs:/path/to/file". The VFS will route the operation to the correct file system based on the prefix before the colon.
+    class VirtualFileSystem {
+    public:
+        explicit VirtualFileSystem();
+
+        FSResult Mount(const Utility::String& prefix, FileSystemInterface* fs, MountFlags flags = MountFlags::NONE);
+        FSResult Unmount(const Utility::String& prefix);
+
+        // Open a file with an absolute path including prefix.
+        // Valid: path="partition_a:/path/to/file.txt"
+        // Valid: path="partition_b:/something/something/../file.txt"
+        FSResult Open(const Utility::String& path, OpenFlags flags, Descriptor* outDescriptor, FileMode mode = FileMode::File);
+
+        // Open a file relative to a current working directory. The path can include special navigation components like "." and "..", which will be resolved relative to the current working directory. The current working directory must be an absolute path including prefix.
+        // Valid: path="file.txt", cwd="partition_a:/path/to"
+        // Invalid: path="../file.txt", cwd="partition_a:/path/to", path="/path/to/file.txt", cwd="/path/to"
+        FSResult Open(const Utility::String& path, const Utility::String& currentWorkingDirectory, OpenFlags flags, Descriptor* outDescriptor, FileMode mode = FileMode::File);
+
+        FSResult Read(Descriptor* descriptor, void* buffer, size_t size, size_t* bytesRead);
+        FSResult Write(Descriptor* descriptor, const void* buffer, size_t size, size_t* bytesWritten);
+        FSResult GetFileInfo(Descriptor* descriptor, FileInfo* outInfo);
+        FSResult GetDirectoryInfo(Descriptor* descriptor, DirectoryInfo* outInfo);
+        void FreeDirectoryInfo(Descriptor *directory, DirectoryInfo* info);
+        FSResult Close(Descriptor* descriptor);
+        FSResult CanonicalizePath(const Utility::String& path, const Utility::String& cwd, Utility::String& outCanonicalPath);
+
+    private:
+        struct MountedFileSystem {
+            Utility::String prefix = "";
+            FileSystemInterface *fs = nullptr;
+            MountFlags flags = MountFlags::NONE;
+        };
+
+        Utility::HashMap<Utility::String, MountedFileSystem> _mountedFileSystems;
+        FSResult InternalOpen(OpenFlags flags, Descriptor *outDescriptor, FileMode mode, const Utility::String &path) const;
     };
 }// FileSystem
 

--- a/src/kernel/Include/Utility/HashMap.h
+++ b/src/kernel/Include/Utility/HashMap.h
@@ -1,0 +1,136 @@
+#ifndef BOREALOS_HASHMAP_H
+#define BOREALOS_HASHMAP_H
+
+#include <Definitions.h>
+
+#include "HashProvider.h"
+#include "List.h"
+#include "Optional.h"
+#include "Move.h"
+
+namespace Utility {
+
+    template<typename K, typename V>
+    class HashMap {
+    public:
+        explicit HashMap(size_t capacity = 16) : _entries(capacity), _capacity(capacity) {_entries.Reserve(_capacity);}
+        ~HashMap() = default;
+
+        void Insert(K&& key, V&& value) {
+            if (_size >= _capacity / 2) { // Load factor of 0.5
+                Resize();
+            }
+
+            size_t hash = Utility::HashProvider<K>()(key);
+            size_t index = hash % _capacity;
+
+            while (_entries[index].occupied && !_entries[index].deleted) {
+                if (_entries[index].key == key) {
+                    _entries[index].value = value; // Update existing key
+                    return;
+                }
+                index = (index + 1) % _capacity;
+            }
+
+            _entries[index] = {key, value, true, false};
+            _size++;
+        }
+
+        void Insert(const K& key, const V& value) {
+            Insert(K(key), V(value));
+        }
+
+        Optional<V> Get(const K& key) const {
+            size_t hash = Utility::HashProvider<K>()(key);
+            size_t index = hash % _capacity;
+
+            while (_entries[index].occupied) {
+                if (!_entries[index].deleted && _entries[index].key == key) {
+                    return Optional<V>(_entries[index].value);
+                }
+                index = (index + 1) % _capacity;
+            }
+
+            return Optional<V>(); // Not found
+        }
+
+        Optional<V> Get(const size_t hash) const {
+            size_t index = hash % _capacity;
+
+            while (_entries[index].occupied) {
+                if (!_entries[index].deleted && Utility::HashProvider<K>()(_entries[index].key) == hash) {
+                    return Optional<V>(_entries[index].value);
+                }
+                index = (index + 1) % _capacity;
+            }
+
+            return Optional<V>(); // Not found
+        }
+
+        void Remove(const K& key) {
+            size_t hash = Utility::HashProvider<K>()(key);
+            size_t index = hash % _capacity;
+
+            while (_entries[index].occupied) {
+                if (!_entries[index].deleted && _entries[index].key == key) {
+                    _entries[index].deleted = true;
+
+                    // Run the destructors
+                    _entries[index].key.~K();
+                    _entries[index].value.~V();
+
+                    _size--;
+                    return;
+                }
+                index = (index + 1) % _capacity;
+            }
+        }
+
+        [[nodiscard]] size_t Size() const {
+            return _size;
+        }
+
+        [[nodiscard]] size_t Capacity() const {
+            return _capacity;
+        }
+
+        Optional<V> operator[](const K& key) const {
+            return Get(key);
+        }
+
+    private:
+        struct Entry {
+            K key;
+            V value;
+            bool occupied = false;
+            bool deleted = false;
+        };
+
+        Utility::List<Entry> _entries;
+        size_t _size = 0;
+        size_t _capacity = 16;
+
+        void Resize() {
+            _capacity *= 2;
+            Utility::List<Entry> newEntries(_capacity);
+
+            for (auto& entry : _entries) {
+                if (entry.occupied && !entry.deleted) {
+                    // Rehash the entry into the new list
+                    size_t hash = Utility::HashProvider<K>()(entry.key);
+                    size_t index = hash % _capacity;
+
+                    while (newEntries[index].occupied) {
+                        index = (index + 1) % _capacity; // Linear probing
+                    }
+
+                    newEntries[index] = {Utility::Move(entry.key), Utility::Move(entry.value), true, false};
+                }
+            }
+
+            _entries = Utility::Move(newEntries);
+        }
+    };
+}
+
+#endif //BOREALOS_HASHMAP_H

--- a/src/kernel/Include/Utility/HashProvider.h
+++ b/src/kernel/Include/Utility/HashProvider.h
@@ -1,0 +1,24 @@
+#ifndef BOREALOS_HASHPROVIDER_H
+#define BOREALOS_HASHPROVIDER_H
+
+#include <Definitions.h>
+#include <concepts>
+
+namespace Utility {
+    template<typename T>
+    struct HashProvider {
+        size_t operator()(const T& value) = delete; // By default, hashing is not supported for any type. Specialize this template for types that you want to be able to hash, such as String.
+    };
+
+    // Use the IsPrimitive type trait to provide a default hash function
+    template<typename T>
+    requires std::integral<T>
+    struct HashProvider<T> {
+        size_t operator()(const T& value) const {
+            // A simple hash function for integers, you can replace this with a better one if you want.
+            return static_cast<size_t>(value);
+        }
+    };
+}
+
+#endif //BOREALOS_HASHPROVIDER_H

--- a/src/kernel/Include/Utility/List.h
+++ b/src/kernel/Include/Utility/List.h
@@ -2,16 +2,17 @@
 #define BOREALOS_LIST_H
 
 #include <Definitions.h>
+#include "Predicate.h"
 
 namespace Utility {
     /// Basic dynamic array implementation.
     template<typename T>
     class List {
     public:
-
         List(size_t capacity = 16) : _size(0), _capacity(capacity) {
             _data = new T[_capacity];
         }
+
         ~List() {
             delete[] _data;
         }
@@ -19,9 +20,34 @@ namespace Utility {
         List(const List&) = delete;
         List& operator=(const List&) = delete;
 
-        // Remove all other constructors and destructors
-        List(List&&) = delete;
-        List& operator=(List&&) = delete;
+        List(List&& other) {
+            _size = other._size;
+            _capacity = other._capacity;
+            _data = other._data;
+
+            other._size = 0;
+            other._capacity = 0;
+            other._data = nullptr;
+        }
+
+        List& operator=(List&& other) {
+            if (this == &other) {
+                return *this; // Self-assignment check
+            }
+
+            delete[] _data;
+
+            _size = other._size;
+            _capacity = other._capacity;
+            _data = other._data;
+
+            other._size = 0;
+            other._capacity = 0;
+            other._data = nullptr;
+
+            return *this;
+        }
+
         List() = delete;
 
         void Add(const T& item) {
@@ -81,8 +107,61 @@ namespace Utility {
             _size = 0;
         }
 
+        // Resize (if necessary) and act as if we added newCapacity items.
+        // This calls the default constructor for any new items, so it is not just a simple resize, it is more of a "reserve and default construct" function.
+        void Reserve(size_t newCapacity) {
+            size_t oldSize = _size;
+            if (newCapacity > _capacity) {
+                Resize(newCapacity);
+            }
+
+            _size = newCapacity;
+            for (size_t i = oldSize; i < newCapacity; i++) {
+                _data[i] = T();
+            }
+        }
+
         [[nodiscard]] size_t Size() const { return _size; }
         [[nodiscard]] size_t Capacity() const { return _capacity; }
+        [[nodiscard]] T* begin() { return _data; }
+        [[nodiscard]] T* end() { return _data + _size; }
+
+        bool Any(Predicate<T> predicate) {
+            for (size_t i = 0; i < _size; i++) {
+                if (predicate(_data[i])) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool All(Predicate<T> predicate) {
+            for (size_t i = 0; i < _size; i++) {
+                if (!predicate(_data[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        Optional<T> Find(Predicate<T> predicate) {
+            for (size_t i = 0; i < _size; i++) {
+                if (predicate(_data[i])) {
+                    return Optional<T>(_data[i]);
+                }
+            }
+            return Optional<T>(); // Not found
+        }
+
+        Optional<T> FindLast(Predicate<T> predicate) {
+            for (size_t i = _size; i-- > 0;) {
+                if (predicate(_data[i])) {
+                    return Optional<T>(_data[i]);
+                }
+            }
+            return Optional<T>(); // Not found
+        }
+
 
     private:
         void Resize(size_t newCapacity) {

--- a/src/kernel/Include/Utility/Math.h
+++ b/src/kernel/Include/Utility/Math.h
@@ -16,6 +16,23 @@ namespace Utility::Math {
     [[nodiscard]] constexpr T Clamp(T value, T min, T max) {
         return Max(min, Min(max, value));
     }
+
+    template<typename T>
+    [[nodiscard]] constexpr T Abs(T value) {
+        return value < 0 ? -value : value;
+    }
+
+    // todo: use a more efficient algorithm for this
+    template<typename T>
+    [[nodiscard]] constexpr T Pow(T base, T exponent) {
+        if (exponent == 0) return 1;
+        if (exponent < 0) return 1 / Pow(base, -exponent);
+        T result = 1;
+        for (T i = 0; i < exponent; i++) {
+            result *= base;
+        }
+        return result;
+    }
 }
 
 #endif //BOREALOS_MATH_H

--- a/src/kernel/Include/Utility/Move.h
+++ b/src/kernel/Include/Utility/Move.h
@@ -1,0 +1,20 @@
+#ifndef BOREALOS_MOVE_H
+#define BOREALOS_MOVE_H
+
+namespace Utility {
+    template<typename T> struct RemoveReference       { using Type = T; };
+    template<typename T> struct RemoveReference<T&>   { using Type = T; };
+    template<typename T> struct RemoveReference<T&&>  { using Type = T; };
+
+    template<typename T>
+    constexpr typename RemoveReference<T>::Type&& Move(T&& t) noexcept {
+        return static_cast<typename RemoveReference<T>::Type&&>(t);
+    }
+
+    template<typename T, typename... Args>
+    constexpr T* MoveConstruct(Args&&... args) {
+        return new T(Utility::Move(args)...);
+    }
+}
+
+#endif //BOREALOS_MOVE_H

--- a/src/kernel/Include/Utility/Optional.h
+++ b/src/kernel/Include/Utility/Optional.h
@@ -1,0 +1,68 @@
+#ifndef BOREALOS_OPTIONAL_H
+#define BOREALOS_OPTIONAL_H
+
+#include <Definitions.h>
+#include "Move.h"
+
+namespace Utility {
+    template<typename T>
+    class Optional {
+    public:
+        Optional() : _hasValue(false) {}
+        Optional(const T& value) : _hasValue(true), _value(value) {}
+        Optional(T&& value) : _hasValue(true), _value(Utility::Move(value)) {}
+
+        [[nodiscard]] bool HasValue() const {
+            return _hasValue;
+        }
+
+        [[nodiscard]] const T& Value() const {
+            if (!_hasValue) {
+                PANIC("Attempted to access value of an empty Optional!");
+            }
+            return _value;
+        }
+
+        [[nodiscard]] T& Value() {
+            if (!_hasValue) {
+                PANIC("Attempted to access value of an empty Optional!");
+            }
+            return _value;
+        }
+
+        [[nodiscard]] T& ValueOr(T initializer) {
+            if (_hasValue) {
+                return _value;
+            }
+            _value = initializer;
+            _hasValue = true;
+            return _value;
+        }
+
+        void Reset() {
+            _hasValue = false;
+            _value = T(); // Reset the value to its default state
+        }
+
+        // Forward the . and -> operators to the underlying value, for convenience.
+        const T* operator->() const {
+            if (!_hasValue) {
+                PANIC("Attempted to access value of an empty Optional!");
+            }
+            return &_value;
+        }
+
+        T* operator->() {
+            if (!_hasValue) {
+                PANIC("Attempted to access value of an empty Optional!");
+            }
+            return &_value;
+        }
+
+    private:
+        bool _hasValue;
+        T _value;
+    };
+}
+
+#endif //BOREALOS_OPTIONAL_H

--- a/src/kernel/Include/Utility/Path.h
+++ b/src/kernel/Include/Utility/Path.h
@@ -2,6 +2,7 @@
 #define BOREALOS_PATH_H
 
 #include <Definitions.h>
+#include "StringView.h"
 
 namespace Utility {
     class Path {
@@ -9,6 +10,7 @@ namespace Utility {
         static size_t GetMaxComponentLength(const char* path, char delimiter);
         static size_t GetComponentCount(const char* path, char delimiter);
         static size_t SplitPath(const char* path, char delimiter, const char** components);
+        static void SplitPath(const char* string, char c, StringView *array);
     };
 }
 

--- a/src/kernel/Include/Utility/Predicate.h
+++ b/src/kernel/Include/Utility/Predicate.h
@@ -1,0 +1,11 @@
+#ifndef BOREALOS_PREDICATE_H
+#define BOREALOS_PREDICATE_H
+#include "Optional.h"
+
+namespace Utility {
+    // A predicate is a function that takes an item of type T and returns a bool!
+    template<typename T>
+    using Predicate = bool(*)(const T&);
+}
+
+#endif //BOREALOS_PREDICATE_H

--- a/src/kernel/Include/Utility/String.h
+++ b/src/kernel/Include/Utility/String.h
@@ -1,0 +1,190 @@
+#ifndef BOREALOS_STRING_H
+#define BOREALOS_STRING_H
+
+#include <Definitions.h>
+
+#include "StringFormatter.h"
+#include "HashProvider.h"
+
+namespace Utility {
+
+    class StringView;
+
+    // std::string like string class, but with less features.
+    // Strings are and should be immutable, all operations that modify a string should return a new string instead of modifying the existing one.
+    class String {
+    public:
+        static constexpr size_t SSO_CAPACITY = 15; // 15 bytes + 1 for null terminator.
+
+        String() : _size(0) {
+            _data.ssoData[0] = '\0'; // Null terminator for empty string
+        }
+
+        String(const char* str) {
+            _size = StringFormatter::strlen(str);
+            if (_size <= SSO_CAPACITY) {
+                memcpy(_data.ssoData, str, _size);
+                memset(_data.ssoData + _size, '\0', SSO_CAPACITY - _size + 1);
+            } else {
+                _data.heapData = new uint8_t[_size + 1];
+                memcpy(_data.heapData, str, _size);
+                _data.heapData[_size] = '\0';
+            }
+        }
+
+        String(const String& other) {
+            _size = other._size;
+            if (_size <= SSO_CAPACITY) {
+                memcpy(_data.ssoData, other._data.ssoData, _size + 1);
+                memset(_data.ssoData + _size, '\0', SSO_CAPACITY - _size + 1);
+            } else {
+                _data.heapData = new uint8_t[_size + 1];
+                memcpy(_data.heapData, other._data.heapData, _size);
+                _data.heapData[_size] = '\0';
+            }
+        }
+
+        String(String&& other) noexcept {
+            _size = other._size;
+            if (_size <= SSO_CAPACITY) {
+                memcpy(_data.ssoData, other._data.ssoData, _size);
+                memset(_data.ssoData + _size, '\0', SSO_CAPACITY - _size + 1);
+            } else {
+                _data.heapData = other._data.heapData;
+                other._data.heapData = nullptr;
+            }
+        }
+
+        String(const StringView& view);
+
+        ~String() {
+            if (_size > SSO_CAPACITY) {
+                delete[] _data.heapData;
+            }
+        }
+
+        String& operator=(const String& other) {
+            if (this == &other) return *this;
+            if (this->_hashCode > 0 && other._hashCode > 0 && this->_hashCode == other._hashCode) {
+                return *this; // If the hash codes are the same and valid, we can assume the strings are the same and skip copying.
+            }
+
+            uint8_t* newHeapData = nullptr;
+            if (other._size > SSO_CAPACITY) {
+                newHeapData = new uint8_t[other._size + 1];
+                if (!newHeapData)
+                    return *this; // If we fail to allocate, just keep the old string and return.
+
+                memcpy(newHeapData, other._data.heapData, other._size + 1);
+            }
+
+            // Now it is safe to release old resources
+            if (_size > SSO_CAPACITY) {
+                delete[] _data.heapData;
+            }
+
+            _size = other._size;
+            if (_size <= SSO_CAPACITY) {
+                memcpy(_data.ssoData, other._data.ssoData, _size + 1);
+            } else {
+                _data.heapData = newHeapData;
+            }
+
+            return *this;
+        }
+
+        String& operator=(String&& other) noexcept {
+            if (this == &other) {
+                return *this; // Self-assignment check
+            }
+
+            if (_size > SSO_CAPACITY) {
+                delete[] _data.heapData;
+            }
+
+            _size = other._size;
+            if (_size <= SSO_CAPACITY) {
+                memcpy(_data.ssoData, other._data.ssoData, _size + 1);
+            } else {
+                _data.heapData = other._data.heapData;
+                other._data.heapData = nullptr;
+            }
+
+            return *this;
+        }
+
+        [[nodiscard]] const char* CStr() const {
+            return _size <= SSO_CAPACITY ? reinterpret_cast<const char*>(_data.ssoData) : reinterpret_cast<const char*>(_data.heapData);
+        }
+
+        [[nodiscard]] size_t Size() const {
+            return _size;
+        }
+
+        // Equality
+        [[nodiscard]] bool operator==(const String& other) const {
+            if (_size != other._size) {
+                return false;
+            }
+
+            if (_hashCode > 0 && other._hashCode > 0 && _hashCode != other._hashCode) {
+                return false; // If the hash codes are different and valid, we can assume the strings are different and skip comparing.
+            }
+
+            return strncmp(CStr(), other.CStr(), _size) == 0;
+        }
+
+        [[nodiscard]] bool operator!=(const String& other) const {
+            return !(*this == other);
+        }
+
+        // Basic operations
+        [[nodiscard]] StringView SubStringView(size_t start, size_t length) const;
+        [[nodiscard]] StringView SubStringView(size_t start) const;
+        [[nodiscard]] StringView AsView() const;
+        [[nodiscard]] String ToLower() const;
+        [[nodiscard]] String ToUpper() const;
+        [[nodiscard]] int Compare(const String& other) const;
+        [[nodiscard]] int CompareIgnoreCase(const String& other) const;
+        [[nodiscard]] bool StartsWith(const String& prefix) const;
+        [[nodiscard]] bool EndsWith(const String& suffix) const;
+        [[nodiscard]] bool Contains(const String& substring) const;
+        [[nodiscard]] size_t Find(const String& substring) const; // Returns the index of the first occurrence of substring, or -1 if not found.
+        [[nodiscard]] size_t RFind(const String& substring) const; // Returns the index of the last occurrence of substring, or -1 if not found.
+        [[nodiscard]] uint32_t Hash(); // Returns a hash of the string, useful for hash maps and such.
+        [[nodiscard]] bool IsEmpty() const;
+
+        // Concatenation
+        [[nodiscard]] String Append(const String& other) const;
+        [[nodiscard]] String Prepend(const String& other) const;
+        [[nodiscard]] String operator+(const String& other) const {
+            return Append(other);
+        }
+
+        friend String operator+(const char* lhs, const String& rhs) {
+            return String(lhs).Append(rhs);
+        }
+
+        friend String operator+(const String& lhs, const char* rhs) {
+            return lhs.Append(String(rhs));
+        }
+
+    private:
+        union {
+            uint8_t ssoData[SSO_CAPACITY + 1]; // +1 for null terminator
+            uint8_t* heapData;
+        } _data;
+        size_t _size;
+        uint32_t _hashCode = 0;
+    };
+
+    template<>
+    struct HashProvider<String> {
+        uint32_t operator()(const String& str) const {
+            return const_cast<String&>(str).Hash();
+        }
+    };
+
+}
+
+#endif //BOREALOS_STRING_H

--- a/src/kernel/Include/Utility/StringView.h
+++ b/src/kernel/Include/Utility/StringView.h
@@ -1,0 +1,65 @@
+#ifndef BOREALOS_STRINGVIEW_H
+#define BOREALOS_STRINGVIEW_H
+
+#include <Definitions.h>
+#include "String.h"
+
+namespace Utility {
+    // A non-owning view into a string, basically just a pointer and a length. This is used for functions that return substrings or modified versions of strings without actually allocating new strings.
+    class StringView {
+    public:
+        StringView() : _data(""), _size(0) {}
+        StringView(const char* data, size_t size) : _data(data), _size(size) {}
+        StringView(const String& str) : _data(str.CStr()), _size(str.Size()) {}
+        StringView(const char* data) : _data(data), _size(StringFormatter::strlen(data)) {}
+
+        [[nodiscard]] const char* Data() const {
+            return _data;
+        }
+
+        [[nodiscard]] size_t Size() const {
+            return _size;
+        }
+
+        // Copies the contents of this StringView into a new String and returns it.
+        [[nodiscard]] String ToString() const {
+            return {*this};
+        }
+
+        // Equality operator
+        bool operator==(const StringView& other) const {
+            if (_size != other._size) {
+                return false;
+            }
+            return strncmp(_data, other._data, _size) == 0;
+        }
+
+        // Inequality operator
+        bool operator!=(const StringView& other) const {
+            return !(*this == other);
+        }
+
+        // Compare against C string
+        int Compare(const char * path) const {
+            return strncmp(_data, path, _size);
+        }
+
+    private:
+        const char* _data;
+        size_t _size;
+    };
+
+    template<>
+    struct HashProvider<StringView> {
+        uint32_t operator()(const StringView& str) const {
+            uint32_t hash = 2166136261u;
+            for (size_t i = 0; i < str.Size(); i++) {
+                hash ^= static_cast<uint32_t>(str.Data()[i]);
+                hash *= 16777619u;
+            }
+            return hash;
+        }
+    };
+}
+
+#endif //BOREALOS_STRINGVIEW_H

--- a/src/kernel/Include/Utility/UniquePtr.h
+++ b/src/kernel/Include/Utility/UniquePtr.h
@@ -1,0 +1,61 @@
+#ifndef BOREALOS_UNIQUEPTR_H
+#define BOREALOS_UNIQUEPTR_H
+
+#include <Definitions.h>
+
+#include "Move.h"
+
+// std::unique_ptr like smart pointer
+
+namespace Utility {
+    template<typename T>
+    class UniquePtr {
+    public:
+        explicit UniquePtr(T* ptr = nullptr) : _ptr(ptr) {}
+        ~UniquePtr() {
+            delete _ptr;
+        }
+
+        UniquePtr(const UniquePtr&) = delete;
+        UniquePtr& operator=(const UniquePtr&) = delete;
+
+        UniquePtr(UniquePtr&& other) noexcept : _ptr(other._ptr) {
+            other._ptr = nullptr;
+        }
+
+        UniquePtr& operator=(UniquePtr&& other) noexcept {
+            if (this == &other) {
+                return *this; // Self-assignment check
+            }
+
+            delete _ptr; // Free the existing resource
+
+            _ptr = other._ptr; // Transfer ownership
+            other._ptr = nullptr; // Prevent double deletion
+
+            return *this;
+        }
+
+        [[nodiscard]] T* Get() const {
+            return _ptr;
+        }
+
+        T* operator->() const {
+            return _ptr;
+        }
+
+        T& operator*() const {
+            return *_ptr;
+        }
+
+    private:
+        T* _ptr;
+    };
+
+    template<typename T, typename... Args>
+    UniquePtr<T> MakeUnique(Args&&... args) {
+        return UniquePtr<T>(Utility::MoveConstruct<T>(Utility::Move(args)...));
+    }
+}
+
+#endif //BOREALOS_UNIQUEPTR_H

--- a/src/kernel/arch/common/Utility/HashMap.cpp
+++ b/src/kernel/arch/common/Utility/HashMap.cpp
@@ -1,0 +1,1 @@
+#include <Utility/HashMap.h>

--- a/src/kernel/arch/common/Utility/HashMap.cpp
+++ b/src/kernel/arch/common/Utility/HashMap.cpp
@@ -1,1 +1,0 @@
-#include <Utility/HashMap.h>

--- a/src/kernel/arch/common/Utility/Path.cpp
+++ b/src/kernel/arch/common/Utility/Path.cpp
@@ -6,6 +6,11 @@ namespace Utility {
         const char* p = path;
 
         while (*p) {
+            if (p == path && *p == delimiter) {
+                p++; // Skip leading delimiter
+                continue;
+            }
+
             while (*p == delimiter) p++; // Skip consecutive delimiters
             if (*p) {
                 count++;
@@ -58,5 +63,20 @@ namespace Utility {
         }
 
         return count;
+    }
+
+    void Path::SplitPath(const char *string, char c, StringView *array) {
+        size_t index = 0;
+        const char* p = string;
+
+        // StringView is a non-owning view, which does not need a null terminator, so we can just set the data pointer and length
+        while (*p) {
+            while (*p == c) p++; // Skip consecutive delimiters
+            if (*p) {
+                const char* start = p; // Start of the component
+                while (*p && *p != c) p++; // Move to the next delimiter
+                array[index++] = StringView(start, p - start); // Create a StringView for the component
+            }
+        }
     }
 }

--- a/src/kernel/arch/common/Utility/String.cpp
+++ b/src/kernel/arch/common/Utility/String.cpp
@@ -1,0 +1,213 @@
+#include <Utility/String.h>
+#include <Utility/StringView.h>
+
+#include "Utility/Math.h"
+
+namespace Utility {
+    String::String(const StringView &view) {
+        _size = view.Size();
+        if (_size <= SSO_CAPACITY) {
+            memcpy(_data.ssoData, view.Data(), _size);
+            _data.ssoData[_size] = '\0';
+        } else {
+            _data.heapData = new uint8_t[_size + 1];
+            memcpy(_data.heapData, view.Data(), _size);
+            _data.heapData[_size] = '\0';
+        }
+    }
+
+    StringView String::SubStringView(size_t start, size_t length) const {
+        if (start >= _size) {
+            return {"", 0}; // Out of bounds, return an empty string view
+        }
+
+        size_t maxLength = _size - start;
+        if (length > maxLength) {
+            length = maxLength; // Adjust length to fit within the string
+        }
+
+        return {CStr() + start, length};
+    }
+
+    StringView String::SubStringView(size_t start) const {
+        return SubStringView(start, _size - start);
+    }
+
+    StringView String::AsView() const {
+        return {CStr(), _size};
+    }
+
+    String String::ToLower() const {
+        String result(*this);
+        char* data = const_cast<char*>(result.CStr());
+        for (size_t i = 0; i < _size; i++) {
+            if (data[i] >= 'A' && data[i] <= 'Z') {
+                data[i] += ('a' - 'A'); // Convert to lowercase
+            }
+        }
+        return result;
+    }
+
+    String String::ToUpper() const {
+        String result(*this);
+        char* data = const_cast<char*>(result.CStr());
+        for (size_t i = 0; i < _size; i++) {
+            if (data[i] >= 'a' && data[i] <= 'z') {
+                data[i] -= ('a' - 'A'); // Convert to uppercase
+            }
+        }
+        return result;
+    }
+
+    int String::Compare(const String &other) const {
+        return strcmp(CStr(), other.CStr());
+    }
+
+    int String::CompareIgnoreCase(const String &other) const {
+        const char* a = CStr();
+        const char* b = other.CStr();
+
+        for (size_t i = 0; i < _size && i < other._size; i++) {
+            char charA = a[i];
+            char charB = b[i];
+
+            // Convert to lowercase for comparison
+            if (charA >= 'A' && charA <= 'Z') {
+                charA += ('a' - 'A');
+            }
+            if (charB >= 'A' && charB <= 'Z') {
+                charB += ('a' - 'A');
+            }
+
+            if (charA != charB) {
+                return (charA < charB) ? -1 : 1;
+            }
+        }
+
+        // If we reached the end of one of the strings, the shorter string is considered smaller
+        if (_size == other._size) {
+            return 0;
+        }
+        return (_size < other._size) ? -1 : 1;
+    }
+
+    bool String::StartsWith(const String &prefix) const {
+        if (prefix._size > _size) {
+            return false; // Prefix is longer than the string, can't start with it
+        }
+
+        return strncmp(CStr(), prefix.CStr(), prefix._size) == 0;
+    }
+
+    bool String::EndsWith(const String &suffix) const {
+        if (suffix._size > _size) {
+            return false; // Suffix is longer than the string, can't end with it
+        }
+
+        return strncmp(CStr() + (_size - suffix._size), suffix.CStr(), suffix._size) == 0;
+    }
+
+    bool String::Contains(const String &substring) const {
+        if (substring._size == 0) {
+            return true; // An empty substring is considered to be contained in any string
+        }
+
+        if (substring._size > _size) {
+            return false; // Substring is longer than the string, can't be contained in it
+        }
+
+        for (size_t i = 0; i <= _size - substring._size; i++) {
+            if (strncmp(CStr() + i, substring.CStr(), substring._size) == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    size_t String::Find(const String &substring) const {
+        if (substring._size == 0) {
+            return 0; // An empty substring is considered to be found at the beginning of the string
+        }
+
+        if (substring._size > _size) {
+            return -1; // Substring is longer than the string, can't be found in it
+        }
+
+        for (size_t i = 0; i <= _size - substring._size; i++) {
+            if (strncmp(CStr() + i, substring.CStr(), substring._size) == 0) {
+                return i;
+            }
+        }
+
+        return -1; // Not found
+    }
+
+    size_t String::RFind(const String &substring) const {
+        if (substring._size == 0) {
+            return _size; // An empty substring is considered to be found at the end of the string
+        }
+
+        if (substring._size > _size) {
+            return -1; // Substring is longer than the string, can't be found in it
+        }
+
+        for (size_t i = _size - substring._size + 1; i-- > 0;) {
+            if (strncmp(CStr() + i, substring.CStr(), substring._size) == 0) {
+                return i;
+            }
+        }
+
+        return -1; // Not found
+    }
+
+    uint32_t String::Hash() {
+        if (_hashCode != 0) {
+            return _hashCode; // Return cached hash code if available
+        }
+
+        uint32_t hash = 2166136261u;
+        for (size_t i = 0; i < _size; i++) {
+            hash ^= static_cast<uint8_t>(CStr()[i]);
+            hash *= 16777619u;
+        }
+        _hashCode = hash;
+        return hash;
+    }
+
+    bool String::IsEmpty() const {
+        return _size == 0;
+    }
+
+    String String::Append(const String &other) const {
+        String result;
+        result._size = _size + other._size;
+        if (result._size <= SSO_CAPACITY) {
+            memcpy(result._data.ssoData, CStr(), _size);
+            memcpy(result._data.ssoData + _size, other.CStr(), other._size);
+            result._data.ssoData[result._size] = '\0';
+        } else {
+            result._data.heapData = new uint8_t[result._size + 1];
+            memcpy(result._data.heapData, CStr(), _size);
+            memcpy(result._data.heapData + _size, other.CStr(), other._size);
+            result._data.heapData[result._size] = '\0';
+        }
+        return result;
+    }
+
+    String String::Prepend(const String &other) const {
+        String result;
+        result._size = _size + other._size;
+        if (result._size <= SSO_CAPACITY) {
+            memcpy(result._data.ssoData, other.CStr(), other._size);
+            memcpy(result._data.ssoData + other._size, CStr(), _size);
+            result._data.ssoData[result._size] = '\0';
+        } else {
+            result._data.heapData = new uint8_t[result._size + 1];
+            memcpy(result._data.heapData, other.CStr(), other._size);
+            memcpy(result._data.heapData + other._size, CStr(), _size);
+            result._data.heapData[result._size] = '\0';
+        }
+        return result;
+    }
+}

--- a/src/kernel/arch/common/VirtualFileSystem.cpp
+++ b/src/kernel/arch/common/VirtualFileSystem.cpp
@@ -1,0 +1,238 @@
+#include <FileSystemInterface.h>
+
+#include "Utility/Path.h"
+#include "Utility/StringFormatter.h"
+
+namespace FileSystem {
+    VirtualFileSystem::VirtualFileSystem() : _mountedFileSystems(8) {
+
+    }
+
+    FSResult VirtualFileSystem::Mount(const Utility::String &prefix, FileSystemInterface *fs, MountFlags flags) {
+        auto lowered = prefix.ToLower();
+        if (_mountedFileSystems.Get(lowered).HasValue()) {
+            return FSResult::ALREADY_EXISTS; // A file system is already mounted with this prefix
+        }
+
+        const auto& normalizedPrefix = prefix;
+
+        // Check if the prefix is longer than 128, or does not match [a-zA-Z0-9_]{1,128}
+        if (normalizedPrefix.Size() == 0 || normalizedPrefix.Size() > 128) {
+            return FSResult::INVALID_PATH; // Prefix must be between 1 and 128 characters long
+        }
+
+        for (size_t i = 0; i < normalizedPrefix.Size(); i++) {
+            char c = normalizedPrefix.CStr()[i];
+            if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')) {
+                return FSResult::INVALID_PATH; // Prefix contains invalid characters
+            }
+        }
+
+        _mountedFileSystems.Insert(Utility::Move(lowered), {Utility::Move(normalizedPrefix), fs, flags});
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::Unmount(const Utility::String &prefix) {
+        auto lowered = prefix.ToLower();
+        if (!_mountedFileSystems.Get(lowered).HasValue()) {
+            return FSResult::MISSING_MOUNT; // No file system is mounted with this prefix
+        }
+
+        _mountedFileSystems.Remove(lowered);
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::Open(const Utility::String &path, OpenFlags flags, Descriptor *outDescriptor, FileMode mode) {
+        Utility::String normalized;
+        if (CanonicalizePath(path, "", normalized) != FSResult::SUCCESS) {
+            return FSResult::INVALID_PATH; // Failed to canonicalize the path, likely due to invalid format
+        }
+
+        return InternalOpen(flags, outDescriptor, mode, normalized);
+    }
+
+    FSResult VirtualFileSystem::Open(const Utility::String &path, const Utility::String &currentWorkingDirectory,
+        OpenFlags flags, Descriptor *outDescriptor, FileMode mode) {
+        Utility::String normalized;
+        if (CanonicalizePath(path, currentWorkingDirectory, normalized) != FSResult::SUCCESS) {
+            return FSResult::INVALID_PATH; // Failed to canonicalize the path, likely due to invalid format
+        }
+
+        return InternalOpen(flags, outDescriptor, mode, normalized);
+    }
+
+    FSResult VirtualFileSystem::Read(Descriptor *descriptor, void *buffer, size_t size, size_t *bytesRead) {
+        if (descriptor->file == nullptr || descriptor->fs == nullptr) {
+            return FSResult::INVALID_DESCRIPTOR;
+        }
+
+        if (bytesRead)
+            *bytesRead = 0;
+
+        if ((uint32_t)(descriptor->flags & OpenFlags::Read) == 0) {
+            return FSResult::READ_PERMISSION;
+        }
+
+        size_t actualBytesRead = 0;
+        auto result = descriptor->fs->Read(descriptor->file, buffer, size, descriptor->offset, &actualBytesRead);
+        if (result != FSResult::SUCCESS) {
+            return result; // Failed to read from the underlying file system, return the error code
+        }
+
+        descriptor->offset += actualBytesRead; // Move the offset forward by the number of bytes read
+
+        if (bytesRead)
+            *bytesRead = actualBytesRead;
+
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::Write(Descriptor *descriptor, const void *buffer, size_t size, size_t *bytesWritten) {
+        if (descriptor->file == nullptr || descriptor->fs == nullptr) {
+            return FSResult::INVALID_DESCRIPTOR;
+        }
+
+        if (bytesWritten)
+            *bytesWritten = 0;
+
+        if ((uint32_t)(descriptor->flags & OpenFlags::Write) == 0) {
+            return FSResult::WRITE_PERMISSION;
+        }
+
+        size_t actualBytesWritten = 0;
+        auto result = descriptor->fs->Write(descriptor->file, buffer, size, descriptor->offset, &actualBytesWritten);
+        if (result != FSResult::SUCCESS) {
+            return result;
+        }
+
+        descriptor->offset += actualBytesWritten; // Move the offset forward by the number of bytes written
+
+        if (bytesWritten)
+            *bytesWritten = actualBytesWritten;
+
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::GetFileInfo(Descriptor *descriptor, FileInfo *outInfo) {
+        return descriptor->fs->GetFileInfo(descriptor->file, outInfo);
+    }
+
+    FSResult VirtualFileSystem::GetDirectoryInfo(Descriptor *descriptor, DirectoryInfo *outInfo) {
+        return descriptor->fs->GetDirectoryInfo(descriptor->file, outInfo);
+    }
+
+    void VirtualFileSystem::FreeDirectoryInfo(Descriptor *directory, DirectoryInfo *info) {
+        directory->fs->FreeDirectoryInfo(info);
+    }
+
+    FSResult VirtualFileSystem::Close(Descriptor *descriptor) {
+        auto result = descriptor->fs->Close(descriptor->file);
+        if (result != FSResult::SUCCESS) {
+            return result; // Failed to close the file in the underlying file system, return the error code
+        }
+
+        descriptor->file = nullptr;
+        descriptor->fs = nullptr;
+        descriptor->offset = 0;
+        descriptor->flags = OpenFlags::None;
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::CanonicalizePath(const Utility::String &path,
+                                                 const Utility::String &cwd, Utility::String &outCanonicalPath) {
+
+        Utility::String output;
+        size_t colonIndex = path.Find(":");
+        if (colonIndex == size_t(-1)) {
+            if (cwd.IsEmpty())
+                return FSResult::INVALID_PATH; // Relative path provided, but current working directory is empty
+
+            output = cwd + "/" + path;
+        }
+        else {
+            output = path; // Absolute path, no need to prepend the current working directory
+        }
+
+        colonIndex = output.Find(":");
+        if (colonIndex == size_t(-1))
+            return FSResult::INVALID_PATH; // if CWD did not include a prefix
+
+        Utility::String prefix = output.SubStringView(0, colonIndex + 1).ToString().ToLower(); // include the colon in the prefix
+
+        auto pathPart = output.SubStringView(colonIndex + 1);
+        size_t componentCount = Utility::Path::GetComponentCount(pathPart.Data(), '/');
+
+        auto parts = new Utility::StringView[componentCount];
+        Utility::Path::SplitPath(pathPart.Data(), '/', parts);
+
+        auto stack = new Utility::StringView[componentCount];
+        size_t stackSize = 0;
+
+        for (size_t i = 0; i < componentCount; i++) {
+            const char* data = parts[i].Data();
+            size_t size = parts[i].Size();
+
+            if (size == 0) continue;
+            if (size == 1 && data[0] == '.') continue; // Current directory, skip
+            if (size == 2 && data[0] == '.' && data[1] == '.') {
+                if (stackSize == 0) {
+                    delete[] parts;
+                    delete[] stack;
+                    return FSResult::OUT_OF_MOUNT; // Trying to navigate above the root of the mounted file system, which is not allowed
+                }
+
+                stackSize--;
+                continue;
+            }
+
+            stack[stackSize++] = parts[i]; // Normal path component, push onto the stack
+        }
+
+        Utility::String result = prefix;
+        for (size_t i = 0; i < stackSize; i++)
+            result = result + "/" + stack[i].ToString();
+
+        if (stackSize == 0)
+            result = result + "/";
+
+        delete[] parts;
+        delete[] stack;
+
+        outCanonicalPath = Utility::Move(result);
+        return FSResult::SUCCESS;
+    }
+
+    FSResult VirtualFileSystem::InternalOpen(OpenFlags flags, Descriptor *outDescriptor, FileMode mode, const Utility::String &path) const {
+        size_t colonIndex = path.Find(":");
+        if (colonIndex == size_t(-1)) {
+            return FSResult::INVALID_PATH; // Path does not contain a colon
+        }
+
+        auto prefix = path.SubStringView(0, colonIndex).ToString().ToLower();
+        auto relativePath = path.SubStringView(colonIndex + 1);
+
+        auto mountedFS = _mountedFileSystems.Get(prefix);
+        if (!mountedFS.HasValue()) {
+            return FSResult::MISSING_MOUNT; // No file system is mounted with this prefix
+        }
+
+        if ((uint32_t)(mountedFS.Value().flags & MountFlags::READ_ONLY) != 0 && (uint32_t)(flags & OpenFlags::Write) != 0) {
+            return FSResult::WRITE_PERMISSION; // The file system is mounted as read-only, but the open flags request write access
+        }
+
+        File* file = nullptr;
+        auto result = mountedFS.Value().fs->Open(relativePath, flags, &file, mode);
+        if (result != FSResult::SUCCESS) {
+            return result; // Failed to open the file in the underlying file system, return the error code
+        }
+
+        *outDescriptor = {
+            .file = file,
+            .fs = mountedFS.Value().fs,
+            .offset = 0,
+            .flags = flags,
+        };
+
+        return FSResult::SUCCESS;
+    }
+}

--- a/src/kernel/arch/x86_64/Core/Drivers/DriverManager.cpp
+++ b/src/kernel/arch/x86_64/Core/Drivers/DriverManager.cpp
@@ -34,9 +34,11 @@ namespace Core::Drivers {
         // Convert the files from raw data, to elf modules, and filter out the invalid ones.
         for (size_t i = 0; i < count; i++) {
             const char* driverPath = drivers[i];
+            FileSystem::FSResult fsresult = FileSystem::FSResult::SUCCESS;
 
-            auto file = _fileSystem->Open(driverPath);
-            if (!file) {
+            FileSystem::File* file = nullptr;
+            fsresult = _fileSystem->Open(driverPath, FileSystem::OpenFlags::Read, &file, FileSystem::FileMode::File);
+            if (!file || fsresult != FileSystem::FSResult::SUCCESS) {
                 LOG_ERROR("Failed to open driver file %s!", driverPath);
                 continue;
             }
@@ -45,7 +47,7 @@ namespace Core::Drivers {
             _fileSystem->GetFileInfo(file, &info);
 
             auto fileData = new uint8_t[info.size];
-            _fileSystem->Read(file, fileData, info.size);
+            _fileSystem->Read(file, fileData, info.size, 0, nullptr);
 
             Formats::ELF elf(fileData, info.size);
             if (!elf.IsValid()) {
@@ -423,14 +425,17 @@ namespace Core::Drivers {
     }
 
     const char **DriverManager::GetDriversInDirectory(const char *str, size_t &count) const {
-        auto dir = _fileSystem->Open(str);
-        if (!dir) {
+        FileSystem::FSResult fsresult = FileSystem::FSResult::SUCCESS;
+        FileSystem::File* dir = nullptr;
+        fsresult = _fileSystem->Open(str, FileSystem::OpenFlags::Read, &dir, FileSystem::FileMode::Directory);
+
+        if (!dir || fsresult != FileSystem::FSResult::SUCCESS) {
             count = 0;
             return nullptr;
         }
 
         FileSystem::DirectoryInfo info;
-        if (!_fileSystem->GetDirectoryInfo(dir, &info)) {
+        if (_fileSystem->GetDirectoryInfo(dir, &info) != FileSystem::FSResult::SUCCESS) {
             count = 0;
             return nullptr;
         }

--- a/src/kernel/arch/x86_64/Core/ProcessManager.cpp
+++ b/src/kernel/arch/x86_64/Core/ProcessManager.cpp
@@ -47,18 +47,21 @@ namespace Core {
             .file = _kernel->ArchitectureData->Stdio->GetStdin(),
             .fs = _kernel->ArchitectureData->Stdio,
             .offset = 0,
+            .flags = FileSystem::OpenFlags::Read,
         });
 
         process->openFiles.Add(new FileSystem::Descriptor {
             .file = _kernel->ArchitectureData->Stdio->GetStdout(),
             .fs = _kernel->ArchitectureData->Stdio,
             .offset = 0,
+            .flags = FileSystem::OpenFlags::Write,
         });
 
         process->openFiles.Add(new FileSystem::Descriptor {
             .file = _kernel->ArchitectureData->Stdio->GetStderr(),
             .fs = _kernel->ArchitectureData->Stdio,
             .offset = 0,
+            .flags = FileSystem::OpenFlags::Write,
         });
 
         return process;

--- a/src/kernel/arch/x86_64/FileSystems/InitRam.cpp
+++ b/src/kernel/arch/x86_64/FileSystems/InitRam.cpp
@@ -115,48 +115,68 @@ namespace FileSystem {
         return {true, false}; // Can read, can't write
     }
 
-    FileSystem::File* InitRam::Open(const char *path) {
-        if (strcmp(path, "/") == 0) {
-            return _files[_fileCount - 1]; // The last file is the root directory
+    FSResult InitRam::Open(Utility::StringView path, OpenFlags flags, File **outFile, FileMode mode) {
+        if (path.Data()[0] == '/' && path.Size() == 1) {
+            *outFile = _files[_fileCount - 1]; // The last file is the root directory
+            return FSResult::SUCCESS;
         }
 
-        if (path[0] == '/') {
-            path++; // Skip the leading '/' since our file paths don't have it
+        if (path.Data()[0] == '/') {
+            path = Utility::StringView(path.Data() + 1, path.Size() - 1); // Remove leading slash for easier matching
         }
 
-        for (size_t i = 0; _files[i] != nullptr; i++) {
-            if (strcmp(_files[i]->path, path) == 0) {
-                return _files[i];
+        for (size_t i = 0; i < _fileCount; i++) {
+            if (Utility::StringView(_files[i]->path) == path) {
+                *outFile = _files[i];
+                return FSResult::SUCCESS;
             }
         }
 
-        return nullptr; // File not found
+        *outFile = nullptr;
+        return FSResult::MISSING_ENTRY;
     }
 
-    size_t InitRam::Read(File *file, void *buffer, size_t size) {
+    FSResult InitRam::Read(File *file, void *buffer, size_t size, size_t offset, size_t *outReadBytes) {
         auto* p = reinterpret_cast<const char*>(reinterpret_cast<uintptr_t>(_cpioArchive->address) + file->offset);
 
-        if (size > file->size) {
-            size = file->size; // Don't read past the end of the file
+        if (size + offset > file->size) {
+            size = file->size - offset; // Adjust size to read only up to the end of the file
         }
 
-        memcpy(buffer, p, size);
-        return size;
+        memcpy(buffer, p + offset, size);
+        if (outReadBytes)
+            *outReadBytes = size;
+
+        return FSResult::SUCCESS;
     }
 
-    size_t InitRam::Write(File *file, const void *buffer, size_t size) {
-        return -1; // Writing is not supported
+    FSResult InitRam::Write(File *file, const void *buffer, size_t size, size_t offset, size_t *outWrittenBytes) {
+        if (outWrittenBytes)
+            *outWrittenBytes = 0;
+
+        return FSResult::UNSUPPORTED; // This filesystem is read-only
     }
 
-    bool InitRam::GetFileInfo(File *file, FileInfo *info) {
+    FSResult InitRam::GetFileInfo(File *file, FileInfo *info) {
         info->size = file->size;
-        info->isDirectory = file->isDirectory;
-        return true;
+
+        if (file->isDirectory) {
+            info->mode = S_IFDIR;
+        } else {
+            info->mode = S_IFREG;
+        }
+
+        // Set permissions to read and execute but no write
+        info->mode |= 0b101'101'101; // rwxr-xr-x
+        info->ownerUserId = 0; // root
+        info->ownerGroupId = 0; // root
+
+        return FSResult::SUCCESS;
     }
 
-    bool InitRam::GetDirectoryInfo(File *file, DirectoryInfo *info) {
+    FSResult InitRam::GetDirectoryInfo(File *file, DirectoryInfo *info) {
         if (!file->isDirectory) {
-            return false; // Not a directory
+            return FSResult::NOT_A_DIRECTORY;
         }
 
         info->entryCount = file->size;
@@ -171,14 +191,15 @@ namespace FileSystem {
             }
         }
 
-        return true;
+        return FSResult::SUCCESS;
     }
 
     void InitRam::FreeDirectoryInfo(DirectoryInfo *info) {
         delete[] info->entries;
     }
 
-    void InitRam::Close(File *file) {
+    FSResult InitRam::Close(File *file) {
         // Does nothing, we preloaded the entire archive into memory.
+        return FSResult::SUCCESS;
     }
 } // FileSystems

--- a/src/kernel/arch/x86_64/FileSystems/InitRam.h
+++ b/src/kernel/arch/x86_64/FileSystems/InitRam.h
@@ -5,18 +5,23 @@
 #include "Boot/c_limine.h"
 
 namespace FileSystem {
-    class InitRam : public FileSystemInterface {
+    class InitRam final : public FileSystemInterface {
     public:
         explicit InitRam(limine_file* cpioArchive, Allocator *allocator);
 
         [[nodiscard]] Capabilities GetCapabilities() const override;
-        [[nodiscard]] File* Open(const char *path) override;
-        size_t Read(File *file, void *buffer, size_t size) override;
-        size_t Write(File *file, const void *buffer, size_t size) override;
-        bool GetFileInfo(File *file, FileInfo *info) override;
-        bool GetDirectoryInfo(File *file, DirectoryInfo *info) override;
+        [[nodiscard]] FSResult Open(Utility::StringView path, OpenFlags flags, File **outFile, FileMode mode) override;
+
+        FSResult Read(File *file, void *buffer, size_t size, size_t offset, size_t *outReadBytes) override;
+
+        FSResult Write(File *file, const void *buffer, size_t size, size_t offset, size_t *outWrittenBytes) override;
+
+        FSResult GetFileInfo(File *file, FileInfo *info) override;
+
+        FSResult GetDirectoryInfo(File *file, DirectoryInfo *info) override;
         void FreeDirectoryInfo(DirectoryInfo *info) override;
-        void Close(File *file) override;
+
+        FSResult Close(File *file) override;
 
     private:
         static constexpr char CpioNewcMagic[] = "070701";

--- a/src/kernel/arch/x86_64/FileSystems/STDIO.cpp
+++ b/src/kernel/arch/x86_64/FileSystems/STDIO.cpp
@@ -19,18 +19,20 @@ namespace FileSystem {
         return {true, true};
     }
 
-    File *STDIO::Open(const char *path) {
-        return nullptr;
+    FSResult STDIO::Open(Utility::StringView path, OpenFlags flags, File **outFile, FileMode mode) {
+        return FSResult::UNSUPPORTED;
     }
 
-    size_t STDIO::Read(File *file, void *buffer, size_t size) {
-        return -1; // Reading is not supported yet
+    FSResult STDIO::Read(File *file, void *buffer, size_t size, size_t offset, size_t *outReadBytes) {
+        if (outReadBytes)
+            *outReadBytes = 0;
+        return FSResult::UNSUPPORTED;
         // TODO: When the HID service is available, we can use that to read input.
     }
 
-    size_t STDIO::Write(File *file, const void *buffer, size_t size) {
+    FSResult STDIO::Write(File *file, const void *buffer, size_t size, size_t offset, size_t *outWrittenBytes) {
         if (file->canWrite == false) {
-            return -1; // Can't write to this file
+            return FSResult::WRITE_PERMISSION;
         }
 
         auto kernel = Kernel<KernelData>::GetInstance();
@@ -40,22 +42,24 @@ namespace FileSystem {
         }
 
         console->Write((char*)buffer, size);
-        return size;
+        if (outWrittenBytes)
+            *outWrittenBytes = size;
+        return FSResult::SUCCESS;
     }
 
-    bool STDIO::GetFileInfo(File *file, FileInfo *info) {
-        return false;
+    FSResult STDIO::GetFileInfo(File *file, FileInfo *info) {
+        return FSResult::UNSUPPORTED;
     }
 
-    bool STDIO::GetDirectoryInfo(File *file, DirectoryInfo *info) {
-        return false;
+    FSResult STDIO::GetDirectoryInfo(File *file, DirectoryInfo *info) {
+        return FSResult::UNSUPPORTED;
     }
 
     void STDIO::FreeDirectoryInfo(DirectoryInfo *info) {
 
     }
 
-    void STDIO::Close(File *file) {
-
+    FSResult STDIO::Close(File *file) {
+        return FSResult::UNSUPPORTED;
     }
 }

--- a/src/kernel/arch/x86_64/FileSystems/STDIO.h
+++ b/src/kernel/arch/x86_64/FileSystems/STDIO.h
@@ -14,19 +14,19 @@ namespace FileSystem {
 
         [[nodiscard]] Capabilities GetCapabilities() const override;
 
-        [[nodiscard]] File *Open(const char *path) override;
+        [[nodiscard]] FSResult Open(Utility::StringView path, OpenFlags flags, File **outFile, FileMode mode) override;
 
-        size_t Read(File *file, void *buffer, size_t size) override;
+        FSResult Read(File *file, void *buffer, size_t size, size_t offset, size_t *outReadBytes) override;
 
-        size_t Write(File *file, const void *buffer, size_t size) override;
+        FSResult Write(File *file, const void *buffer, size_t size, size_t offset, size_t *outWrittenBytes) override;
 
-        bool GetFileInfo(File *file, FileInfo *info) override;
+        FSResult GetFileInfo(File *file, FileInfo *info) override;
 
-        bool GetDirectoryInfo(File *file, DirectoryInfo *info) override;
+        FSResult GetDirectoryInfo(File *file, DirectoryInfo *info) override;
 
         void FreeDirectoryInfo(DirectoryInfo *info) override;
 
-        void Close(File *file) override;
+        FSResult Close(File *file) override;
 
         [[nodiscard]] File* GetStdin() const { return _stdin; }
         [[nodiscard]] File* GetStdout() const { return _stdout; }

--- a/src/kernel/arch/x86_64/Kernel.cpp
+++ b/src/kernel/arch/x86_64/Kernel.cpp
@@ -216,7 +216,7 @@ void Kernel<T>::Start() {
     LOG_INFO("Created and scheduled init process with PID %u64.", process->pid);
 
     LOG_INFO("Entering main kernel loop. Should be the last log message you see before the init process starts running.");
-    // enableTicking = true;
+    enableTicking = true;
 
     while(true)
         asm("hlt");

--- a/src/kernel/arch/x86_64/Kernel.cpp
+++ b/src/kernel/arch/x86_64/Kernel.cpp
@@ -4,6 +4,7 @@
 
 #include "Interrupts/IDT.h"
 #include "Syscalls/Syscalls.h"
+#include "Utility/HashMap.h"
 
 extern "C" {
     #include <x86_64/dbg.h> // minidbg
@@ -136,20 +137,20 @@ void Kernel<T>::Initialize() {
     ArchitectureData->InitRamFS = new FileSystem::InitRam(cpioArchive, &ArchitectureData->HeapAllocator);
     LOG_INFO("Initialized initramfs.");
 
-    // Kernel symbols:
-    auto symbolTable = ArchitectureData->InitRamFS->Open("/ramfs/kernel.sym");
-    if (!symbolTable) {
-        PANIC("Failed to open kernel symbol table from init ram filesystem! Expected it to be located at /ramfs/kernel.sym");
-    }
-    FileSystem::FileInfo symbolTableInfo;
-    if (!ArchitectureData->InitRamFS->GetFileInfo(symbolTable, &symbolTableInfo)) {
-        PANIC("Failed to get kernel symbol table info from init ram filesystem!");
+    // VFS:
+    ArchitectureData->VFS = new FileSystem::VirtualFileSystem();
+    if (ArchitectureData->VFS->Mount("initramfs", ArchitectureData->InitRamFS) != FileSystem::FSResult::SUCCESS) {
+        PANIC("Failed to mount init ram filesystem to virtual filesystem!");
     }
 
+    LOG_INFO("Mounted initramfs to virtual filesystem with prefix \"initramfs:/\".");
+
+    // Kernel symbols:
+    auto symbolTable = ArchitectureData->InitRamFS->OpenOrPanic("/ramfs/kernel.sym");
+    FileSystem::FileInfo symbolTableInfo = ArchitectureData->InitRamFS->GetFileInfoOrPanic(symbolTable);
+
     auto symbolTableData = new uint8_t[symbolTableInfo.size];
-    if (!ArchitectureData->InitRamFS->Read(symbolTable, symbolTableData, symbolTableInfo.size)) {
-        PANIC("Failed to read kernel symbol table data from init ram filesystem!");
-    }
+    ArchitectureData->InitRamFS->ReadOrPanic(symbolTable, symbolTableData, symbolTableInfo.size);
     ArchitectureData->KernelSymbols = new Formats::SymbolLoader(symbolTableData, symbolTableInfo.size);
     LOG_INFO("Initialized kernel symbol loader with %u64 symbols.", ArchitectureData->KernelSymbols->GetSymbolCount());
 
@@ -180,42 +181,42 @@ void Kernel<T>::Start() {
     ArchitectureData->DriverManager->LoadDriversFromFileSystem();
     LOG_INFO("Finished loading drivers.");
 
-    FileSystem::InitRam* initRamFS = ArchitectureData->InitRamFS;
-    auto initProcess = initRamFS->Open("/ramfs/bin/init");
-    if (!initProcess) {
-        PANIC("Failed to open init process binary from init ram filesystem! Expected it to be located at /ramfs/bin/init");
+    FileSystem::VirtualFileSystem *vfs = ArchitectureData->VFS;
+    FileSystem::Descriptor initProcessDescriptor{};
+    auto result = vfs->Open("initramfs:/ramfs/bin/init", FileSystem::OpenFlags::Read, &initProcessDescriptor);
+    if (result != FileSystem::FSResult::SUCCESS) {
+        LOG_ERROR("Failed to open init process from virtual filesystem. Error code: %u32", static_cast<uint32_t>(result));
     }
 
-    FileSystem::FileInfo initProcessInfo;
-    if (!initRamFS->GetFileInfo(initProcess, &initProcessInfo)) {
-        PANIC("Failed to get init process binary info from init ram filesystem!");
+    FileSystem::FileInfo initProcessInfo{};
+    result = vfs->GetFileInfo(&initProcessDescriptor, &initProcessInfo);
+    if (result != FileSystem::FSResult::SUCCESS) {
+        LOG_ERROR("Failed to get file info for init process from virtual filesystem. Error code: %u32", static_cast<uint32_t>(result));
     }
 
-    auto testProcessData = new uint8_t[initProcessInfo.size];
-    if (!initRamFS->Read(initProcess, testProcessData, initProcessInfo.size)) {
-        PANIC("Failed to read init process binary data from init ram filesystem!");
+    auto initProcessData = new uint8_t[initProcessInfo.size];
+    if (vfs->Read(&initProcessDescriptor, initProcessData, initProcessInfo.size, nullptr) != FileSystem::FSResult::SUCCESS) {
+        PANIC("Failed to read init process from virtual filesystem!");
     }
 
     Core::ProcessManager* pm = ArchitectureData->ProcessManager;
     Core::ThreadScheduler* ts = ArchitectureData->ThreadScheduler;
 
-    for (size_t i = 0; i < 1; i++) {
-        auto process = pm->CreateProcess(testProcessData, initProcessInfo.size);
-        if (!process) {
-            PANIC("Failed to create init process!");
-        }
-
-        ts->ScheduleProcess(process, {
-            .argv = nullptr,
-            .argc = 0,
-            .currentWorkingDirectory = "/",
-        });
-
-        LOG_INFO("Created and scheduled init process with PID %u64.", process->pid);
+    auto process = pm->CreateProcess(initProcessData, initProcessInfo.size);
+    if (!process) {
+        PANIC("Failed to create init process!");
     }
 
+    ts->ScheduleProcess(process, {
+        .argv = nullptr,
+        .argc = 0,
+        .currentWorkingDirectory = "/",
+    });
+
+    LOG_INFO("Created and scheduled init process with PID %u64.", process->pid);
+
     LOG_INFO("Entering main kernel loop. Should be the last log message you see before the init process starts running.");
-    enableTicking = true;
+    // enableTicking = true;
 
     while(true)
         asm("hlt");

--- a/src/kernel/arch/x86_64/KernelData.h
+++ b/src/kernel/arch/x86_64/KernelData.h
@@ -43,6 +43,7 @@ struct KernelData {
     Interrupts::APIC *Apic;
     Core::Time::TSC Tsc {&Hpet, &Cpu};
     FileSystem::InitRam* InitRamFS;
+    FileSystem::VirtualFileSystem *VFS;
     Formats::SymbolLoader *KernelSymbols;
     Core::ServiceManager *ServiceManager;
     Core::Drivers::DriverManager *DriverManager;

--- a/src/kernel/arch/x86_64/Syscalls/Read/SyscallRead.cpp
+++ b/src/kernel/arch/x86_64/Syscalls/Read/SyscallRead.cpp
@@ -28,8 +28,9 @@ namespace Syscalls {
             return -1; // Invalid file descriptor
         }
 
-        auto result = descriptor->fs->Read(descriptor->file, buffer, count);
-        if (result == (size_t)-1) {
+        size_t read = 0;
+        auto result = descriptor->fs->Read(descriptor->file, buffer, count, 0, &read);
+        if (result != FileSystem::FSResult::SUCCESS) {
             return -1; // Write failed
         }
 

--- a/src/kernel/arch/x86_64/Syscalls/Write/SyscallWrite.cpp
+++ b/src/kernel/arch/x86_64/Syscalls/Write/SyscallWrite.cpp
@@ -28,8 +28,9 @@ namespace Syscalls {
             return -1; // Invalid file descriptor
         }
 
-        auto result = descriptor->fs->Write(descriptor->file, buffer, count);
-        if (result == (size_t)-1) {
+        size_t written = 0;
+        auto result = descriptor->fs->Write(descriptor->file, buffer, count, descriptor->offset, &written);
+        if (result != FileSystem::FSResult::SUCCESS) {
             return -1; // Write failed
         }
 


### PR DESCRIPTION
Create a prefix based VFS 

docs/VFS.md: 
a spec for the VFS (currently not fully implemented, but the raw vfs itself is)

Path.cpp:
Add a SplitPath with StringView function

String.h/cpp:
Created an immutable string with RAII functionality, and some helper functions

VirtualFileSystem.cpp:
Prefix, hashmap based VFS.
FileSystems mount to a prefix (like "initramfs:/") and then any file access to "initramfs:/some/file.txt" will route to the correct filesystem driver.

DriverManager/InitRam/Stdio/SyscallRead/SyscallWrite:
Update for the new FS.

Kernel.cpp:
Initialize the VFS, and mount initramfs
update for the new FS
Load the init executable using the VFS instead.

KernelData.h:
Add VFS

HashMap:
basic linear probe hashmap

HashProvider:
Interface for types to provide a hash, can be overriden for more complicated types.

List: 
Add predicates, begin & end and reserve.
Add support for moving

Math:
Add Abs and Pow

Move:
Basic move functionality (like std::move)

Optional:
Basic optional type

Predicate:
Function that returns a bool, based on T

StringView: 
non owning string, used for easier comparisons

UniquePtr:
std::unique_ptr equivelant

FileSystemInterface.h:
Add UNIX mode bits
Add FSResult
Add OpenFlags
Add MountFlags
Add FileMode


