### PR TITLE
Create Paging with per cpu support

### DIFF
--- a/src/kernel/Architecture.cpp
+++ b/src/kernel/Architecture.cpp
@@ -1,0 +1,21 @@
+#include <Definitions.h>
+
+extern "C" {
+    extern char _kernel_stack_top[];
+    extern char _kernel_stack_bottom[];
+    extern char _kernel_base[];
+    extern char _kernel_end[];
+    extern char _fault_handler_stack_bottom[];
+    extern char _fault_handler_stack_top[];
+}
+
+namespace Architecture {
+    volatile uintptr_t *StackTop = reinterpret_cast<uintptr_t *>(&_kernel_stack_top[0]);
+    volatile uintptr_t *StackBottom = reinterpret_cast<uintptr_t *>(&_kernel_stack_bottom[0]);
+    volatile size_t StackSize = (StackTop - StackBottom);
+    volatile uintptr_t *KernelBase = reinterpret_cast<uintptr_t *>(&_kernel_base[0]);
+    volatile uintptr_t *KernelEnd = reinterpret_cast<uintptr_t *>(&_kernel_end[0]);
+    volatile size_t KernelSize = (KernelEnd - KernelBase);
+    volatile uintptr_t *DefaultFaultHandlerTop = reinterpret_cast<uintptr_t *>(&_fault_handler_stack_top[0]);
+    volatile uintptr_t *DefaultFaultHandlerBottom = reinterpret_cast<uintptr_t *>(&_fault_handler_stack_bottom[0]);
+}

--- a/src/kernel/Boot/LimineDefinitions.cpp
+++ b/src/kernel/Boot/LimineDefinitions.cpp
@@ -47,6 +47,14 @@ volatile limine_executable_cmdline_request Boot::Limine::CommandlineRequest = {
     .response = nullptr,
 };
 
+__attribute__((used, section(".limine_requests")))
+volatile limine_mp_request Boot::Limine::MultiProcessingRequest = {
+    .id = LIMINE_MP_REQUEST_ID,
+    .revision = 0,
+    .response = nullptr,
+    .flags = LIMINE_MP_REQUEST_X86_64_X2APIC
+};
+
 __attribute__((used, section(".limine_requests_start")))
 volatile uint64_t Boot::Limine::LimineRequestsStartMarker[] = LIMINE_REQUESTS_START_MARKER;
 

--- a/src/kernel/Boot/LimineDefinitions.h
+++ b/src/kernel/Boot/LimineDefinitions.h
@@ -12,6 +12,7 @@ namespace Boot::Limine {
     extern volatile struct limine_module_request ModuleRequest;
     extern volatile struct limine_rsdp_request RsdpRequest;
     extern volatile struct limine_executable_cmdline_request CommandlineRequest;
+    extern volatile struct limine_mp_request MultiProcessingRequest;
     extern volatile uint64_t LimineRequestsStartMarker[];
     extern volatile uint64_t LimineRequestsEndMarker[];
 }

--- a/src/kernel/Definitions.h
+++ b/src/kernel/Definitions.h
@@ -21,7 +21,20 @@ namespace Constants {
     constexpr uint64_t GiB = MiB * 1024;
     constexpr uint64_t TiB = GiB * 1024;
     constexpr uint64_t PiB = TiB * 1024;
-    constexpr uint64_t PageSize = 4 * KiB;
+}
+
+namespace Architecture {
+    constexpr uint64_t MaxCPUs = 1024; // TODO: if somehow this is too little add more
+    constexpr uint64_t PageSize = 4 * Constants::KiB;
+    constexpr uint64_t KernelOffset = 0xFFFFFFFF80000000;
+    extern volatile uintptr_t *StackBottom;
+    extern volatile uintptr_t *StackTop;
+    extern volatile uintptr_t *KernelBase;
+    extern volatile uintptr_t *KernelEnd;
+    extern volatile uintptr_t *DefaultFaultHandlerTop;
+    extern volatile uintptr_t *DefaultFaultHandlerBottom;
+    extern volatile size_t StackSize;
+    extern volatile size_t KernelSize;
 }
 
 #define PANIC(message) Core::Panic(message)

--- a/src/kernel/Interrupts/GDT.S
+++ b/src/kernel/Interrupts/GDT.S
@@ -1,0 +1,33 @@
+/*     extern void LoadGDT(uint64_t gdt_pointer);
+       extern void LoadTSS(uint16_t tss_selector); */
+.section .text
+
+.global LoadGDT
+.type LoadGDT,@function
+LoadGDT:
+    /* Load the GDT using the LGDT instruction */
+    lgdt (%rdi)
+
+    /* Far jump to flush the instruction pipeline and load the new code segment */
+    pushq $0x08
+    leaq 1f(%rip), %rax
+    pushq %rax
+    lretq
+
+1:
+    /* Reload data segments with selector 0x10 (GDT entry 2) */
+    movw $0x10, %ax
+    movw %ax, %ds
+    movw %ax, %es
+    movw %ax, %ss
+    movw $0, %ax
+    movw %ax, %fs
+    movw %ax, %gs
+    ret
+
+.global LoadTSS
+.type LoadTSS,@function
+LoadTSS:
+    movw %di, %ax
+    ltr %ax
+    ret

--- a/src/kernel/Interrupts/GDT.cpp
+++ b/src/kernel/Interrupts/GDT.cpp
@@ -1,0 +1,84 @@
+#include "GDT.h"
+#include "TSS.h"
+
+constexpr uintptr_t _gsOffset = 0xC0000101; // TODO: use the CPU class for this.
+
+extern "C" {
+    extern void LoadGDT(uint64_t gdt_pointer);
+    extern void LoadTSS(uint16_t tss_selector);
+}
+
+namespace Interrupts {
+    uint64_t GDT::entries[Architecture::MaxCPUs][8]; // Null, Code, Data, TSS low and high, UserCode, UserData
+    GDT::GDTPointer GDT::gdtp[Architecture::MaxCPUs];
+
+    void GDT::SetEntry(uint32_t cpuId, int index, uint32_t base, uint32_t limit, uint8_t access, uint8_t granularity) {
+        GDTEntry entry = {};
+        entry.LimitLow = limit & 0xFFFF;
+        entry.BaseLow = base & 0xFFFF;
+        entry.BaseMiddle = (base >> 16) & 0xFF;
+        entry.Access = access;
+        entry.Granularity = (limit >> 16) & 0x0F;
+        entry.Granularity |= granularity & 0xF0;
+        entry.BaseHigh = (base >> 24) & 0xFF;
+
+        __builtin_memcpy(&entries[cpuId][index], &entry, sizeof(GDTEntry));
+    }
+
+    void GDT::SetTSSDescriptor(uint32_t cpuId, int index, uint64_t base, uint32_t limit) {
+        uint64_t low = 0;
+        uint64_t high = 0;
+
+        low |= (limit & 0xFFFFULL);
+        low |= (base & 0xFFFFFFULL) << 16;
+        low |= (0x89ULL) << 40;
+        low |= ((limit >> 16) & 0xFULL) << 48;
+        low |= ((base >> 24) & 0xFFULL) << 56;
+
+        high |= (base >> 32) & 0xFFFFFFFFULL;
+
+        entries[cpuId][index] = low;
+        entries[cpuId][index + 1] = high;
+    }
+
+    uint32_t GDT::GetCpuId() {
+        // Read out GS.base
+        uint64_t output;
+        asm volatile ("rdmsr" : "=a"(output) : "c"(_gsOffset));
+        return static_cast<uint32_t>(output);
+    }
+
+    void GDT::Initialize(uint32_t cpuId, void *rsp0, void *ts1) {
+        TSS::Initialize(cpuId, rsp0, ts1);
+        auto tss_address = reinterpret_cast<uintptr_t>(TSS::GetTSSStruct(cpuId));
+
+        // Null descriptor
+        SetEntry(cpuId, 0, 0, 0, 0, 0);
+
+        // Code segment descriptor
+        SetEntry(cpuId, 1, 0, 0xFFFFF, 0x9A, 0xA0);
+
+        // Data segment descriptor
+        SetEntry(cpuId, 2, 0, 0xFFFFF, 0x92, 0xA0);
+
+        // TSS descriptor
+        SetTSSDescriptor(cpuId, 3, tss_address, sizeof(TSS::TSSStruct) - 1);
+
+        // User mode code segment descriptor
+        SetEntry(cpuId, 5, 0, 0xFFFFF, 0xF2, 0xC0); // star anchor
+        SetEntry(cpuId, 6, 0, 0xFFFFF, 0xF2, 0xA0); // UserData 64 DPL=3 SS on SYSRET
+        SetEntry(cpuId, 7, 0, 0xFFFFF, 0xFA, 0xA0); // UserCode 64 DPL=3 CS on SYSRET, L bit set
+
+        gdtp[cpuId].Limit = sizeof(entries[cpuId]) - 1;
+        gdtp[cpuId].Base = reinterpret_cast<uint64_t>(&entries[cpuId]);
+
+        LoadGDT(reinterpret_cast<uint64_t>(&gdtp[cpuId]));
+        LoadTSS(0x18); // TSS selector is at offset 0x18 in the GDT (3rd entry, 3 * 8 = 0x18)
+
+        asm volatile ("wrmsr" : : "c"(_gsOffset), "a"(cpuId & 0xFFFFFFFF), "d"((uint64_t)cpuId >> 32));
+    }
+
+    GDT::GDTPointer * GDT::GetGDTPointer(uint32_t cpuId) {
+        return &gdtp[cpuId];
+    }
+} // Interrupts

--- a/src/kernel/Interrupts/GDT.h
+++ b/src/kernel/Interrupts/GDT.h
@@ -1,0 +1,35 @@
+#ifndef BOREALOS_GDT_H
+#define BOREALOS_GDT_H
+
+#include <Definitions.h>
+
+namespace Interrupts {
+    class GDT {
+    private:
+        struct PACKED GDTEntry {
+            uint16_t LimitLow;
+            uint16_t BaseLow;
+            uint8_t BaseMiddle;
+            uint8_t Access;
+            uint8_t Granularity;
+            uint8_t BaseHigh;
+        };
+
+        struct PACKED GDTPointer {
+            uint16_t Limit;
+            uint64_t Base;
+        };
+
+        static uint64_t entries[Architecture::MaxCPUs][8]; // Null, Code, Data, TSS, UserCode, UserData
+        static GDTPointer gdtp[Architecture::MaxCPUs];
+        static void SetEntry(uint32_t cpuId, int index, uint32_t base, uint32_t limit, uint8_t access, uint8_t granularity);
+        static void SetTSSDescriptor(uint32_t cpuId, int index, uint64_t base, uint32_t limit);
+
+    public:
+        static void Initialize(uint32_t cpuId, void *rsp0, void *ts1);
+        static GDTPointer* GetGDTPointer(uint32_t cpuId);
+        static uint32_t GetCpuId();
+    };
+} // Interrupts
+
+#endif //BOREALOS_GDT_H

--- a/src/kernel/Interrupts/IDT.S
+++ b/src/kernel/Interrupts/IDT.S
@@ -1,0 +1,630 @@
+.section .text
+.intel_syntax noprefix
+/* IDT handling for x86_64 architecture */
+.global IRQHandler
+.global ExceptionHandler
+
+/* Save all general-purpose registers in reverse order (r15 … rax) */
+.macro SAVE_REGS
+    push    r15
+    push    r14
+    push    r13
+    push    r12
+    push    r11
+    push    r10
+    push    r9
+    push    r8
+    push    rbp
+    push    rdi
+    push    rsi
+    push    rdx
+    push    rcx
+    push    rbx
+    push    rax
+.endm
+
+/* Restore registers in the opposite order (rax … r15) */
+.macro RESTORE_REGS
+    pop     rax
+    pop     rbx
+    pop     rcx
+    pop     rdx
+    pop     rsi
+    pop     rdi
+    pop     rbp
+    pop     r8
+    pop     r9
+    pop     r10
+    pop     r11
+    pop     r12
+    pop     r13
+    pop     r14
+    pop     r15
+.endm
+
+/* IRQ stub: Push dummy error code to maintain uniform stack frame */
+.macro mac_IRQStub vector
+.global stub_ISRStub_\vector
+.type stub_ISRStub_\vector, @function
+stub_ISRStub_\vector:
+    push    0                     /* Dummy error code */
+    SAVE_REGS
+    mov     rdi, \vector          /* Argument 1: vector */
+    mov     rsi, [rsp + 15*8]    /* Argument 2: error code (now at a fixed offset) */
+    mov     rdx, rsp              /* Argument 3: pointer to Registers struct */
+
+    mov     rbp, rsp
+    and     rsp, -16
+    sub     rsp, 8
+    call    IRQHandler
+    mov     rsp, rbp
+
+    RESTORE_REGS
+    add     rsp, 8                /* Discard dummy error code */
+    iretq
+.endm
+
+/* Exception stub with CPU-pushed error code */
+.macro mac_ISRErrStub vector
+.global stub_ISRStub_\vector
+.type stub_ISRStub_\vector, @function
+stub_ISRStub_\vector:
+    SAVE_REGS
+    mov     rdi, \vector
+    mov     rsi, [rsp + 15*8]    /* Error code */
+    mov     rdx, rsp
+
+    mov     rbp, rsp
+    and     rsp, -16
+    sub     rsp, 8
+    call    ExceptionHandler
+    mov     rsp, rbp
+
+    RESTORE_REGS
+    add     rsp, 8                /* Discard hardware error code */
+    iretq
+.endm
+
+/* Exception stub without error code */
+.macro mac_ISRNoErrStub vector
+.global stub_ISRStub_\vector
+.type stub_ISRStub_\vector, @function
+stub_ISRStub_\vector:
+    push    0                     /* Dummy error code */
+    SAVE_REGS
+    mov     rdi, \vector
+    mov     rsi, [rsp + 15*8]
+    mov     rdx, rsp
+
+    mov     rbp, rsp
+    and     rsp, -16
+    sub     rsp, 8
+    call    ExceptionHandler
+    mov     rsp, rbp
+
+    RESTORE_REGS
+    add     rsp, 8                /* Discard dummy error code */
+    iretq
+.endm
+
+/* Define ISR and IRQ stubs */
+mac_ISRNoErrStub 0
+mac_ISRNoErrStub 1
+mac_ISRNoErrStub 2
+mac_ISRNoErrStub 3
+mac_ISRNoErrStub 4
+mac_ISRNoErrStub 5
+mac_ISRNoErrStub 6
+mac_ISRNoErrStub 7
+mac_ISRErrStub 8
+mac_ISRNoErrStub 9
+mac_ISRErrStub 10
+mac_ISRErrStub 11
+mac_ISRErrStub 12
+mac_ISRErrStub 13
+mac_ISRErrStub 14
+mac_ISRNoErrStub 15
+mac_ISRNoErrStub 16
+mac_ISRErrStub 17
+mac_ISRNoErrStub 18
+mac_ISRNoErrStub 19
+mac_ISRNoErrStub 20
+mac_ISRNoErrStub 21
+mac_ISRNoErrStub 22
+mac_ISRNoErrStub 23
+mac_ISRNoErrStub 24
+mac_ISRNoErrStub 25
+mac_ISRNoErrStub 26
+mac_ISRNoErrStub 27
+mac_ISRNoErrStub 28
+mac_ISRNoErrStub 29
+mac_ISRErrStub 30
+mac_ISRNoErrStub 31
+mac_IRQStub 32
+mac_IRQStub 33
+mac_IRQStub 34
+mac_IRQStub 35
+mac_IRQStub 36
+mac_IRQStub 37
+mac_IRQStub 38
+mac_IRQStub 39
+mac_IRQStub 40
+mac_IRQStub 41
+mac_IRQStub 42
+mac_IRQStub 43
+mac_IRQStub 44
+mac_IRQStub 45
+mac_IRQStub 46
+mac_IRQStub 47
+mac_IRQStub 48
+mac_IRQStub 49
+mac_IRQStub 50
+mac_IRQStub 51
+mac_IRQStub 52
+mac_IRQStub 53
+mac_IRQStub 54
+mac_IRQStub 55
+mac_IRQStub 56
+mac_IRQStub 57
+mac_IRQStub 58
+mac_IRQStub 59
+mac_IRQStub 60
+mac_IRQStub 61
+mac_IRQStub 62
+mac_IRQStub 63
+mac_IRQStub 64
+mac_IRQStub 65
+mac_IRQStub 66
+mac_IRQStub 67
+mac_IRQStub 68
+mac_IRQStub 69
+mac_IRQStub 70
+mac_IRQStub 71
+mac_IRQStub 72
+mac_IRQStub 73
+mac_IRQStub 74
+mac_IRQStub 75
+mac_IRQStub 76
+mac_IRQStub 77
+mac_IRQStub 78
+mac_IRQStub 79
+mac_IRQStub 80
+mac_IRQStub 81
+mac_IRQStub 82
+mac_IRQStub 83
+mac_IRQStub 84
+mac_IRQStub 85
+mac_IRQStub 86
+mac_IRQStub 87
+mac_IRQStub 88
+mac_IRQStub 89
+mac_IRQStub 90
+mac_IRQStub 91
+mac_IRQStub 92
+mac_IRQStub 93
+mac_IRQStub 94
+mac_IRQStub 95
+mac_IRQStub 96
+mac_IRQStub 97
+mac_IRQStub 98
+mac_IRQStub 99
+mac_IRQStub 100
+mac_IRQStub 101
+mac_IRQStub 102
+mac_IRQStub 103
+mac_IRQStub 104
+mac_IRQStub 105
+mac_IRQStub 106
+mac_IRQStub 107
+mac_IRQStub 108
+mac_IRQStub 109
+mac_IRQStub 110
+mac_IRQStub 111
+mac_IRQStub 112
+mac_IRQStub 113
+mac_IRQStub 114
+mac_IRQStub 115
+mac_IRQStub 116
+mac_IRQStub 117
+mac_IRQStub 118
+mac_IRQStub 119
+mac_IRQStub 120
+mac_IRQStub 121
+mac_IRQStub 122
+mac_IRQStub 123
+mac_IRQStub 124
+mac_IRQStub 125
+mac_IRQStub 126
+mac_IRQStub 127
+mac_IRQStub 128
+mac_IRQStub 129
+mac_IRQStub 130
+mac_IRQStub 131
+mac_IRQStub 132
+mac_IRQStub 133
+mac_IRQStub 134
+mac_IRQStub 135
+mac_IRQStub 136
+mac_IRQStub 137
+mac_IRQStub 138
+mac_IRQStub 139
+mac_IRQStub 140
+mac_IRQStub 141
+mac_IRQStub 142
+mac_IRQStub 143
+mac_IRQStub 144
+mac_IRQStub 145
+mac_IRQStub 146
+mac_IRQStub 147
+mac_IRQStub 148
+mac_IRQStub 149
+mac_IRQStub 150
+mac_IRQStub 151
+mac_IRQStub 152
+mac_IRQStub 153
+mac_IRQStub 154
+mac_IRQStub 155
+mac_IRQStub 156
+mac_IRQStub 157
+mac_IRQStub 158
+mac_IRQStub 159
+mac_IRQStub 160
+mac_IRQStub 161
+mac_IRQStub 162
+mac_IRQStub 163
+mac_IRQStub 164
+mac_IRQStub 165
+mac_IRQStub 166
+mac_IRQStub 167
+mac_IRQStub 168
+mac_IRQStub 169
+mac_IRQStub 170
+mac_IRQStub 171
+mac_IRQStub 172
+mac_IRQStub 173
+mac_IRQStub 174
+mac_IRQStub 175
+mac_IRQStub 176
+mac_IRQStub 177
+mac_IRQStub 178
+mac_IRQStub 179
+mac_IRQStub 180
+mac_IRQStub 181
+mac_IRQStub 182
+mac_IRQStub 183
+mac_IRQStub 184
+mac_IRQStub 185
+mac_IRQStub 186
+mac_IRQStub 187
+mac_IRQStub 188
+mac_IRQStub 189
+mac_IRQStub 190
+mac_IRQStub 191
+mac_IRQStub 192
+mac_IRQStub 193
+mac_IRQStub 194
+mac_IRQStub 195
+mac_IRQStub 196
+mac_IRQStub 197
+mac_IRQStub 198
+mac_IRQStub 199
+mac_IRQStub 200
+mac_IRQStub 201
+mac_IRQStub 202
+mac_IRQStub 203
+mac_IRQStub 204
+mac_IRQStub 205
+mac_IRQStub 206
+mac_IRQStub 207
+mac_IRQStub 208
+mac_IRQStub 209
+mac_IRQStub 210
+mac_IRQStub 211
+mac_IRQStub 212
+mac_IRQStub 213
+mac_IRQStub 214
+mac_IRQStub 215
+mac_IRQStub 216
+mac_IRQStub 217
+mac_IRQStub 218
+mac_IRQStub 219
+mac_IRQStub 220
+mac_IRQStub 221
+mac_IRQStub 222
+mac_IRQStub 223
+mac_IRQStub 224
+mac_IRQStub 225
+mac_IRQStub 226
+mac_IRQStub 227
+mac_IRQStub 228
+mac_IRQStub 229
+mac_IRQStub 230
+mac_IRQStub 231
+mac_IRQStub 232
+mac_IRQStub 233
+mac_IRQStub 234
+mac_IRQStub 235
+mac_IRQStub 236
+mac_IRQStub 237
+mac_IRQStub 238
+mac_IRQStub 239
+mac_IRQStub 240
+mac_IRQStub 241
+mac_IRQStub 242
+mac_IRQStub 243
+mac_IRQStub 244
+mac_IRQStub 245
+mac_IRQStub 246
+mac_IRQStub 247
+mac_IRQStub 248
+mac_IRQStub 249
+mac_IRQStub 250
+mac_IRQStub 251
+mac_IRQStub 252
+mac_IRQStub 253
+mac_IRQStub 254
+mac_IRQStub 255
+
+/* Now we need an ISR stub table to reference these stubs */
+.section .rodata
+.align 8
+.global ISRStubTable
+ISRStubTable:
+    .quad    stub_ISRStub_0
+    .quad    stub_ISRStub_1
+    .quad    stub_ISRStub_2
+    .quad    stub_ISRStub_3
+    .quad    stub_ISRStub_4
+    .quad    stub_ISRStub_5
+    .quad    stub_ISRStub_6
+    .quad    stub_ISRStub_7
+    .quad    stub_ISRStub_8
+    .quad    stub_ISRStub_9
+    .quad    stub_ISRStub_10
+    .quad    stub_ISRStub_11
+    .quad    stub_ISRStub_12
+    .quad    stub_ISRStub_13
+    .quad    stub_ISRStub_14
+    .quad    stub_ISRStub_15
+    .quad    stub_ISRStub_16
+    .quad    stub_ISRStub_17
+    .quad    stub_ISRStub_18
+    .quad    stub_ISRStub_19
+    .quad    stub_ISRStub_20
+    .quad    stub_ISRStub_21
+    .quad    stub_ISRStub_22
+    .quad    stub_ISRStub_23
+    .quad    stub_ISRStub_24
+    .quad    stub_ISRStub_25
+    .quad    stub_ISRStub_26
+    .quad    stub_ISRStub_27
+    .quad    stub_ISRStub_28
+    .quad    stub_ISRStub_29
+    .quad    stub_ISRStub_30
+    .quad    stub_ISRStub_31
+    .quad    stub_ISRStub_32
+    .quad    stub_ISRStub_33
+    .quad    stub_ISRStub_34
+    .quad    stub_ISRStub_35
+    .quad    stub_ISRStub_36
+    .quad    stub_ISRStub_37
+    .quad    stub_ISRStub_38
+    .quad    stub_ISRStub_39
+    .quad    stub_ISRStub_40
+    .quad    stub_ISRStub_41
+    .quad    stub_ISRStub_42
+    .quad    stub_ISRStub_43
+    .quad    stub_ISRStub_44
+    .quad    stub_ISRStub_45
+    .quad    stub_ISRStub_46
+    .quad    stub_ISRStub_47
+    .quad    stub_ISRStub_48
+    .quad    stub_ISRStub_49
+    .quad    stub_ISRStub_50
+    .quad    stub_ISRStub_51
+    .quad    stub_ISRStub_52
+    .quad    stub_ISRStub_53
+    .quad    stub_ISRStub_54
+    .quad    stub_ISRStub_55
+    .quad    stub_ISRStub_56
+    .quad    stub_ISRStub_57
+    .quad    stub_ISRStub_58
+    .quad    stub_ISRStub_59
+    .quad    stub_ISRStub_60
+    .quad    stub_ISRStub_61
+    .quad    stub_ISRStub_62
+    .quad    stub_ISRStub_63
+    .quad    stub_ISRStub_64
+    .quad    stub_ISRStub_65
+    .quad    stub_ISRStub_66
+    .quad    stub_ISRStub_67
+    .quad    stub_ISRStub_68
+    .quad    stub_ISRStub_69
+    .quad    stub_ISRStub_70
+    .quad    stub_ISRStub_71
+    .quad    stub_ISRStub_72
+    .quad    stub_ISRStub_73
+    .quad    stub_ISRStub_74
+    .quad    stub_ISRStub_75
+    .quad    stub_ISRStub_76
+    .quad    stub_ISRStub_77
+    .quad    stub_ISRStub_78
+    .quad    stub_ISRStub_79
+    .quad    stub_ISRStub_80
+    .quad    stub_ISRStub_81
+    .quad    stub_ISRStub_82
+    .quad    stub_ISRStub_83
+    .quad    stub_ISRStub_84
+    .quad    stub_ISRStub_85
+    .quad    stub_ISRStub_86
+    .quad    stub_ISRStub_87
+    .quad    stub_ISRStub_88
+    .quad    stub_ISRStub_89
+    .quad    stub_ISRStub_90
+    .quad    stub_ISRStub_91
+    .quad    stub_ISRStub_92
+    .quad    stub_ISRStub_93
+    .quad    stub_ISRStub_94
+    .quad    stub_ISRStub_95
+    .quad    stub_ISRStub_96
+    .quad    stub_ISRStub_97
+    .quad    stub_ISRStub_98
+    .quad    stub_ISRStub_99
+    .quad    stub_ISRStub_100
+    .quad    stub_ISRStub_101
+    .quad    stub_ISRStub_102
+    .quad    stub_ISRStub_103
+    .quad    stub_ISRStub_104
+    .quad    stub_ISRStub_105
+    .quad    stub_ISRStub_106
+    .quad    stub_ISRStub_107
+    .quad    stub_ISRStub_108
+    .quad    stub_ISRStub_109
+    .quad    stub_ISRStub_110
+    .quad    stub_ISRStub_111
+    .quad    stub_ISRStub_112
+    .quad    stub_ISRStub_113
+    .quad    stub_ISRStub_114
+    .quad    stub_ISRStub_115
+    .quad    stub_ISRStub_116
+    .quad    stub_ISRStub_117
+    .quad    stub_ISRStub_118
+    .quad    stub_ISRStub_119
+    .quad    stub_ISRStub_120
+    .quad    stub_ISRStub_121
+    .quad    stub_ISRStub_122
+    .quad    stub_ISRStub_123
+    .quad    stub_ISRStub_124
+    .quad    stub_ISRStub_125
+    .quad    stub_ISRStub_126
+    .quad    stub_ISRStub_127
+    .quad    stub_ISRStub_128
+    .quad    stub_ISRStub_129
+    .quad    stub_ISRStub_130
+    .quad    stub_ISRStub_131
+    .quad    stub_ISRStub_132
+    .quad    stub_ISRStub_133
+    .quad    stub_ISRStub_134
+    .quad    stub_ISRStub_135
+    .quad    stub_ISRStub_136
+    .quad    stub_ISRStub_137
+    .quad    stub_ISRStub_138
+    .quad    stub_ISRStub_139
+    .quad    stub_ISRStub_140
+    .quad    stub_ISRStub_141
+    .quad    stub_ISRStub_142
+    .quad    stub_ISRStub_143
+    .quad    stub_ISRStub_144
+    .quad    stub_ISRStub_145
+    .quad    stub_ISRStub_146
+    .quad    stub_ISRStub_147
+    .quad    stub_ISRStub_148
+    .quad    stub_ISRStub_149
+    .quad    stub_ISRStub_150
+    .quad    stub_ISRStub_151
+    .quad    stub_ISRStub_152
+    .quad    stub_ISRStub_153
+    .quad    stub_ISRStub_154
+    .quad    stub_ISRStub_155
+    .quad    stub_ISRStub_156
+    .quad    stub_ISRStub_157
+    .quad    stub_ISRStub_158
+    .quad    stub_ISRStub_159
+    .quad    stub_ISRStub_160
+    .quad    stub_ISRStub_161
+    .quad    stub_ISRStub_162
+    .quad    stub_ISRStub_163
+    .quad    stub_ISRStub_164
+    .quad    stub_ISRStub_165
+    .quad    stub_ISRStub_166
+    .quad    stub_ISRStub_167
+    .quad    stub_ISRStub_168
+    .quad    stub_ISRStub_169
+    .quad    stub_ISRStub_170
+    .quad    stub_ISRStub_171
+    .quad    stub_ISRStub_172
+    .quad    stub_ISRStub_173
+    .quad    stub_ISRStub_174
+    .quad    stub_ISRStub_175
+    .quad    stub_ISRStub_176
+    .quad    stub_ISRStub_177
+    .quad    stub_ISRStub_178
+    .quad    stub_ISRStub_179
+    .quad    stub_ISRStub_180
+    .quad    stub_ISRStub_181
+    .quad    stub_ISRStub_182
+    .quad    stub_ISRStub_183
+    .quad    stub_ISRStub_184
+    .quad    stub_ISRStub_185
+    .quad    stub_ISRStub_186
+    .quad    stub_ISRStub_187
+    .quad    stub_ISRStub_188
+    .quad    stub_ISRStub_189
+    .quad    stub_ISRStub_190
+    .quad    stub_ISRStub_191
+    .quad    stub_ISRStub_192
+    .quad    stub_ISRStub_193
+    .quad    stub_ISRStub_194
+    .quad    stub_ISRStub_195
+    .quad    stub_ISRStub_196
+    .quad    stub_ISRStub_197
+    .quad    stub_ISRStub_198
+    .quad    stub_ISRStub_199
+    .quad    stub_ISRStub_200
+    .quad    stub_ISRStub_201
+    .quad    stub_ISRStub_202
+    .quad    stub_ISRStub_203
+    .quad    stub_ISRStub_204
+    .quad    stub_ISRStub_205
+    .quad    stub_ISRStub_206
+    .quad    stub_ISRStub_207
+    .quad    stub_ISRStub_208
+    .quad    stub_ISRStub_209
+    .quad    stub_ISRStub_210
+    .quad    stub_ISRStub_211
+    .quad    stub_ISRStub_212
+    .quad    stub_ISRStub_213
+    .quad    stub_ISRStub_214
+    .quad    stub_ISRStub_215
+    .quad    stub_ISRStub_216
+    .quad    stub_ISRStub_217
+    .quad    stub_ISRStub_218
+    .quad    stub_ISRStub_219
+    .quad    stub_ISRStub_220
+    .quad    stub_ISRStub_221
+    .quad    stub_ISRStub_222
+    .quad    stub_ISRStub_223
+    .quad    stub_ISRStub_224
+    .quad    stub_ISRStub_225
+    .quad    stub_ISRStub_226
+    .quad    stub_ISRStub_227
+    .quad    stub_ISRStub_228
+    .quad    stub_ISRStub_229
+    .quad    stub_ISRStub_230
+    .quad    stub_ISRStub_231
+    .quad    stub_ISRStub_232
+    .quad    stub_ISRStub_233
+    .quad    stub_ISRStub_234
+    .quad    stub_ISRStub_235
+    .quad    stub_ISRStub_236
+    .quad    stub_ISRStub_237
+    .quad    stub_ISRStub_238
+    .quad    stub_ISRStub_239
+    .quad    stub_ISRStub_240
+    .quad    stub_ISRStub_241
+    .quad    stub_ISRStub_242
+    .quad    stub_ISRStub_243
+    .quad    stub_ISRStub_244
+    .quad    stub_ISRStub_245
+    .quad    stub_ISRStub_246
+    .quad    stub_ISRStub_247
+    .quad    stub_ISRStub_248
+    .quad    stub_ISRStub_249
+    .quad    stub_ISRStub_250
+    .quad    stub_ISRStub_251
+    .quad    stub_ISRStub_252
+    .quad    stub_ISRStub_253
+    .quad    stub_ISRStub_254
+    .quad    stub_ISRStub_255
+
+/* End of IDT.S */

--- a/src/kernel/Interrupts/IDT.cpp
+++ b/src/kernel/Interrupts/IDT.cpp
@@ -1,0 +1,136 @@
+#include "IDT.h"
+
+#include "Kernel.h"
+
+Interrupts::IDT::IDT(Memory::Paging &paging) : _paging(paging) {
+
+}
+
+static Interrupts::IDT::IDTEntry _idtEntries[256] ALIGNED(16) = {}; // Static allocation for 256 IDT entries
+
+void Interrupts::IDT::Initialize() {
+    asm volatile ("cli");
+
+    _idtPointer.Base = reinterpret_cast<uint64_t>(&_idtEntries[0]);
+    _idtPointer.Limit = sizeof(IDTEntry) * 256 - 1;
+
+    for (uint16_t vec = 0; vec < 256; vec++) {
+        SetIDTEntry(vec, reinterpret_cast<uint64_t>(((void**) &ISRStubTable)[vec]), 0x8E); // 0x8E = Present, DPL=0, Type=Interrupt Gate
+    }
+
+    // Override the stack for DF, GPF and PF to use the IST entry 1.
+    _idtEntries[8].IST = 1; // Double Fault
+    _idtEntries[13].IST = 1; // General Protection Fault
+    _idtEntries[14].IST = 1; // Page Fault
+
+    for (auto & _exceptionHandler : _exceptionHandlers) {
+        _exceptionHandler = nullptr; // Initialize exception handlers to nullptr
+    }
+
+    for (auto & _irqHandler : _irqHandlers) {
+        _irqHandler = nullptr; // Initialize IRQ handlers to nullptr
+    }
+
+    asm volatile("lidt %0" : : "m" (_idtPointer)); // Load the IDT
+    asm volatile("sti"); // Enable interrupts after loading IDT
+
+    _isTesting = true;
+    asm volatile("int $0"); // Trigger Division By Zero
+    asm volatile("int $3"); // Trigger Breakpoint
+    _isTesting = false;
+}
+
+void Interrupts::IDT::RegisterExceptionHandler(uint8_t exceptionVector, void(*handler)()) {
+    if (exceptionVector >= 32) {
+        LOG_ERROR("Attempted to register an exception handler for vector {}, which is not a CPU exception vector!", exceptionVector);
+        return;
+    }
+
+    _exceptionHandlers[exceptionVector] = handler;
+}
+
+void Interrupts::IDT::RegisterIRQHandler(uint8_t irq, void(*handler)()) {
+    _irqHandlers[irq] = handler;
+}
+
+void Interrupts::IDT::IRQHandler(uint8_t irq, Registers *registers) {
+    auto cpuData = Kernel::GetInstance().GetCpuData();
+    Memory::Paging::State* backupState = cpuData->pageState; // Backup the current paging state before handling the interrupt
+    _paging.SwitchToKernelPageTable();
+
+    _registersForInterrupts[irq] = registers; // Save the register state for this interrupt so that it can be accessed by the handler if needed
+    if (_irqHandlers[irq] != nullptr) {
+        _irqHandlers[irq]();
+    }
+
+    if (backupState != cpuData->pageState) {
+        Memory::Paging::SwitchToPageTable(backupState);
+    }
+
+    // TODO: When LAPIC make sure to call end of interrupt.
+}
+
+void Interrupts::IDT::HandleException(uint32_t exceptionVector, uint32_t errorCode, Registers *registers) const {
+    if (_isTesting) {
+        LOG_INFO("IDT testing mode: Exception {} occurred with error code {}",
+                 (exceptionVector < 32) ? ExceptionNames[exceptionVector] : "Unknown", errorCode);
+        return; // In testing mode, just return
+    }
+
+    uint64_t cr0, cr2, cr3, cr4;
+    asm volatile("mov %%cr0, %0" : "=r"(cr0));
+    asm volatile("mov %%cr2, %0" : "=r"(cr2));
+    asm volatile("mov %%cr3, %0" : "=r"(cr3));
+    asm volatile("mov %%cr4, %0" : "=r"(cr4));
+
+    LOG_ERROR("\n\r\n\r-- CPU Exception Occurred --\n\r");
+    LOG_ERROR("Exception: {} (Vector {})", (exceptionVector < 32) ? ExceptionNames[exceptionVector] : "Unknown", exceptionVector);
+
+    if (exceptionVector == 14) {
+        LOG_ERROR("Page fault at address {}", (void*)cr2);
+    }
+
+    LOG_ERROR("Error Code {}", (void*)(uint64_t)errorCode);
+    LOG_ERROR("RAX: {} RBX: {} RCX: {} RDX: {}", (void*)registers->rax, (void*)registers->rbx, (void*)registers->rcx, (void*)registers->rdx);
+    LOG_ERROR("RSI: {} RDI: {} RBP: {} R8: {}", (void*)registers->rsi, (void*)registers->rdi, (void*)registers->rbp, (void*)registers->r8);
+    LOG_ERROR("R9: {} R10: {} R11: {} R12: {}", (void*)registers->r9, (void*)registers->r10, (void*)registers->r11, (void*)registers->r12);
+    LOG_ERROR("R13: {} R14: {} R15: {}", (void*)registers->r13, (void*)registers->r14, (void*)registers->r15);
+
+    PANIC("Exception occurred");
+}
+
+void Interrupts::IDT::UnmaskIRQ(uint8_t uint8) const {
+    // TODO: When LAPIC is available do this.
+}
+
+void Interrupts::IDT::MaskIRQ(uint8_t uint8) const {
+    // TODO: When LAPIC is available do this.
+}
+
+const Interrupts::IDT::Registers * Interrupts::IDT::GetRegistersForInterrupt(uint8_t interruptVector) const {
+    return _registersForInterrupts[interruptVector];
+}
+
+void Interrupts::IDT::SetIDTEntry(uint8_t vector, uint64_t isr, uint8_t flags) {
+    IDTEntry &entry = _idtEntries[vector];
+    entry.OffsetLow = isr & 0xFFFF;
+    entry.Selector = 0x08; // Kernel code segment
+    entry.IST = 0; // No IST
+    entry.TypeAttribute = flags;
+    entry.OffsetMiddle = (isr >> 16) & 0xFFFF;
+    entry.OffsetHigh = (isr >> 32) & 0xFFFFFFFF;
+    entry.Zero = 0;
+}
+
+extern "C" {
+    void IRQHandler(uint8_t irq, uint64_t errorCode, Interrupts::IDT::Registers* regs) {
+        Kernel::GetInstance().Data.idt.IRQHandler(irq - 32, regs);
+    }
+
+    // Error code is the vector number, so for example, divide by zero is 0, page fault is 14, etc.
+    // The error number is the error code pushed by the CPU for exceptions that push an error code.
+    // So for vector 8, that would be 0 for double fault, for vector 14, that would be the page fault error code, etc.
+    void ExceptionHandler(uint64_t exceptionVector, uint64_t errorCode, Interrupts::IDT::Registers* regs) {
+        Kernel::GetInstance().Data.idt.HandleException(exceptionVector, errorCode, regs);
+    }
+}

--- a/src/kernel/Interrupts/IDT.h
+++ b/src/kernel/Interrupts/IDT.h
@@ -1,0 +1,99 @@
+#ifndef BOREALOS_IDT_H
+#define BOREALOS_IDT_H
+
+#include <Definitions.h>
+
+#include "../Memory/Paging.h"
+
+static const char* ExceptionNames[] = {
+    "<FATAL_CPU_EXCEPTION_0> Division By Zero",
+    "<FATAL_CPU_EXCEPTION_1> Debug",
+    "<FATAL_CPU_EXCEPTION_2> Non Maskable Interrupt",
+    "<FATAL_CPU_EXCEPTION_3> Breakpoint",
+    "<FATAL_CPU_EXCEPTION_4> Detected Overflow",
+    "<FATAL_CPU_EXCEPTION_5> Out of Bounds",
+    "<FATAL_CPU_EXCEPTION_6> Invalid Opcode",
+    "<FATAL_CPU_EXCEPTION_7> No Coprocessor",
+    "<FATAL_CPU_EXCEPTION_8> Double Fault",
+    "<FATAL_CPU_EXCEPTION_9> Coprocessor Segment Overrun",
+    "<FATAL_CPU_EXCEPTION_10> Bad TSS",
+    "<FATAL_CPU_EXCEPTION_11> Segment Not Present",
+    "<FATAL_CPU_EXCEPTION_12> Stack Fault",
+    "<FATAL_CPU_EXCEPTION_13> General Protection Fault",
+    "<FATAL_CPU_EXCEPTION_14> Page Fault",
+    "<FATAL_CPU_EXCEPTION_15> Unknown Interrupt",
+    "<FATAL_CPU_EXCEPTION_16> Coprocessor Fault",
+    "<FATAL_CPU_EXCEPTION_17> Alignment Check failure (486+)",
+    "<FATAL_CPU_EXCEPTION_18> Machine Check failure (Pentium/586+)",
+    "<FATAL_CPU_EXCEPTION_19> Reserved",
+    "<FATAL_CPU_EXCEPTION_20> Reserved",
+    "<FATAL_CPU_EXCEPTION_21> Reserved",
+    "<FATAL_CPU_EXCEPTION_22> Reserved",
+    "<FATAL_CPU_EXCEPTION_23> Reserved",
+    "<FATAL_CPU_EXCEPTION_24> Reserved",
+    "<FATAL_CPU_EXCEPTION_25> Reserved",
+    "<FATAL_CPU_EXCEPTION_26> Reserved",
+    "<FATAL_CPU_EXCEPTION_27> Reserved",
+    "<FATAL_CPU_EXCEPTION_28> Reserved",
+    "<FATAL_CPU_EXCEPTION_29> Reserved",
+    "<FATAL_CPU_EXCEPTION_30> Reserved",
+    "<FATAL_CPU_EXCEPTION_31> Reserved",
+};
+
+extern "C" {
+    extern void* ISRStubTable[];
+}
+
+namespace Interrupts {
+    class IDT {
+    public:
+        struct PACKED IDTEntry {
+            uint16_t OffsetLow;
+            uint16_t Selector;
+            uint8_t IST;
+            uint8_t TypeAttribute;
+            uint16_t OffsetMiddle;
+            uint32_t OffsetHigh;
+            uint32_t Zero;
+        };
+
+        struct PACKED IDTPointer {
+            uint16_t Limit;
+            uint64_t Base;
+        };
+
+#pragma pack(push, 1)
+        struct Registers {
+            uint64_t rax, rbx, rcx, rdx, rsi, rdi, rbp, r8, r9, r10, r11, r12, r13, r14, r15;
+            uint64_t error_code;
+            uint64_t rip;
+            uint64_t cs;
+            uint64_t rflags;
+            uint64_t user_rsp; /* The RSP of the process that was interrupted */
+            uint64_t ss;
+        };
+#pragma pack(pop)
+
+        explicit IDT(Memory::Paging& paging);
+
+        void Initialize();
+        void RegisterExceptionHandler(uint8_t exceptionVector, void (*handler)());
+        void RegisterIRQHandler(uint8_t irq, void (*handler)());
+        void IRQHandler(uint8_t irq, Registers *registers);
+        void HandleException(uint32_t exceptionVector, uint32_t errorCode, Registers *registers) const;
+        void UnmaskIRQ(uint8_t uint8) const;
+        void MaskIRQ(uint8_t uint8) const;
+        [[nodiscard]] const Registers *GetRegistersForInterrupt(uint8_t interruptVector) const;
+
+    private:
+        IDTPointer _idtPointer = {0, 0};
+        void (*_exceptionHandlers[32])() = { nullptr };
+        void (*_irqHandlers[256])() = { nullptr };
+        Registers* _registersForInterrupts[256] = {}; // This is used to store the register state for the currently handled interrupt, so that it can be accessed by the exception handler (for exceptions) or the IRQ handler (for IRQs) if needed. It is indexed by the interrupt vector number.
+        void SetIDTEntry(uint8_t vector, uint64_t isr, uint8_t flags);
+        bool _isTesting = false;
+        Memory::Paging& _paging;
+    };
+}
+
+#endif //BOREALOS_IDT_H

--- a/src/kernel/Interrupts/TSS.cpp
+++ b/src/kernel/Interrupts/TSS.cpp
@@ -1,0 +1,16 @@
+#include "TSS.h"
+
+namespace Interrupts {
+    TSS::TSSStruct TSS::_tss[Architecture::MaxCPUs];
+
+    void TSS::Initialize(uint32_t cpuId, void *rsp0, void *ist1) {
+        _tss[cpuId] = {};
+        _tss[cpuId].RSP0 = reinterpret_cast<uint64_t>(rsp0);
+        _tss[cpuId].IST1 = reinterpret_cast<uint64_t>(ist1);
+        _tss[cpuId].IOMapBase = sizeof(TSSStruct);
+    }
+
+    TSS::TSSStruct* TSS::GetTSSStruct(uint32_t cpuId) {
+        return &_tss[cpuId];
+    }
+} // Interrupts

--- a/src/kernel/Interrupts/TSS.h
+++ b/src/kernel/Interrupts/TSS.h
@@ -1,0 +1,34 @@
+#ifndef BOREALOS_TSS_H
+#define BOREALOS_TSS_H
+
+#include <Definitions.h>
+
+namespace Interrupts {
+    class TSS {
+    public:
+        struct PACKED TSSStruct {
+            uint32_t Reserved0;
+            uint64_t RSP0;
+            uint64_t RSP1;
+            uint64_t RSP2;
+            uint64_t Reserved1;
+            uint64_t IST1;
+            uint64_t IST2;
+            uint64_t IST3;
+            uint64_t IST4;
+            uint64_t IST5;
+            uint64_t IST6;
+            uint64_t IST7;
+            uint64_t Reserved2;
+            uint16_t Reserved3;
+            uint16_t IOMapBase;
+        };
+
+        static void Initialize(uint32_t cpuId, void *rsp0, void *ist1);
+        static TSSStruct* GetTSSStruct(uint32_t cpuId);
+    private:
+        static TSSStruct _tss[Architecture::MaxCPUs];
+    };
+} // Interrupts
+
+#endif //BOREALOS_TSS_H

--- a/src/kernel/Kernel.cpp
+++ b/src/kernel/Kernel.cpp
@@ -1,6 +1,7 @@
 #include "Kernel.h"
 #include "Parameters.h"
 #include <Logging.h>
+#include "Interrupts/GDT.h"
 
 void Kernel::Initialize() {
     Data.framebufferConsole.Initialize();
@@ -10,7 +11,17 @@ void Kernel::Initialize() {
     if (logLevel.HasValue())
         Data.minimumLogLevel = static_cast<LogLevel>(logLevel.Value());
 
+    auto mp = Boot::Limine::MultiProcessingRequest.response;
+    if (!mp)
+        PANIC("Limine MultiProcessingRequest response is null, cannot continue!");
+
+    auto cpuId = mp->bsp_lapic_id; // Our core "zero", the core used to boot.
+
+    Interrupts::GDT::Initialize(cpuId, (void*)Architecture::StackTop, (void*)Architecture::DefaultFaultHandlerTop);
+
     Data.physicalMemoryManager.Initialize();
+    Data.paging.Initialize();
+    Data.idt.Initialize();
 }
 
 void Kernel::Start() {
@@ -36,6 +47,10 @@ Kernel & Kernel::GetInstance() {
     return instance;
 }
 
+CpuData * Kernel::GetCpuData() {
+    return &Cpu[Interrupts::GDT::GetCpuId()];
+}
+
 bool Logging::LogMessage(LogLevel level) {
     if (level >= LogLevel::ERROR) {
         return true;
@@ -46,6 +61,11 @@ bool Logging::LogMessage(LogLevel level) {
     }
 
     return false;
+}
+
+Threading::Spinlock& Logging::GetLogLock() {
+    static Threading::Spinlock logLock;
+    return logLock;
 }
 
 void Core::Write(const char *message, size_t c) {

--- a/src/kernel/Kernel.h
+++ b/src/kernel/Kernel.h
@@ -11,8 +11,10 @@ public:
     void Log(const char* message, size_t c);
     [[noreturn]] void Panic(const char* message);
     static Kernel& GetInstance();
+    CpuData* GetCpuData();
 
     KernelData Data;
+    CpuData Cpu[Architecture::MaxCPUs];
 };
 
 #endif //BOREALOS_KERNEL_H

--- a/src/kernel/KernelData.h
+++ b/src/kernel/KernelData.h
@@ -3,7 +3,10 @@
 
 #include <Logging.h>
 
+#include "Interrupts/GDT.h"
+#include "Interrupts/IDT.h"
 #include "IO/FramebufferConsole.h"
+#include "Memory/Paging.h"
 #include "Memory/PhysicalMemoryManager.h"
 #include "Utility/CommandLineExtractor.h"
 
@@ -12,6 +15,13 @@ struct KernelData {
     Utility::CommandLineExtractor commandLineExtractor;
     LogLevel minimumLogLevel;
     Memory::PhysicalMemoryManager physicalMemoryManager;
+    Memory::Paging paging{physicalMemoryManager};
+    Interrupts::IDT idt{paging};
+};
+
+struct CpuData {
+    uint32_t cpuId;
+    Memory::Paging::State *pageState;
 };
 
 #endif //BOREALOS_KERNELDATA_H

--- a/src/kernel/Logging.h
+++ b/src/kernel/Logging.h
@@ -5,6 +5,8 @@
 #include <Utility/Traits.h>
 #include <Utility/ANSI.h>
 
+#include "Threading/Spinlock.h"
+
 enum class LogLevel {
     DEBUG = 0,
     INFO = 1,
@@ -15,11 +17,14 @@ enum class LogLevel {
 
 namespace Logging {
     bool LogMessage(LogLevel);
+    Threading::Spinlock& GetLogLock();
 
     template<typename... Args>
     void LogFmt(LogLevel level, Utility::StringView file, Utility::Formatter::Writer out, Utility::Formatter::FormatString<Utility::Traits::TypeIdentityT<Args>...> message, Args&&... args) {
         if (!LogMessage(level))
             return;
+
+        Threading::ScopedLock lock(GetLogLock(), true);
 
         Utility::StringView color = Utility::ANSI::Colors::Foreground::White;
         Utility::StringView defaultColor = Utility::ANSI::Colors::Foreground::White;

--- a/src/kernel/Memory/Paging.cpp
+++ b/src/kernel/Memory/Paging.cpp
@@ -1,0 +1,259 @@
+#include "Paging.h"
+#include <Logging.h>
+
+#include "Kernel.h"
+#include "Boot/LimineDefinitions.h"
+
+namespace Memory {
+    Paging::Paging(PhysicalMemoryManager &pmm) : _pmm(pmm) {
+
+    }
+
+    void Paging::Initialize() {
+        uintptr_t pml4Phys = _pmm.AllocatePages(1);
+        if (!pml4Phys)
+            PANIC("Failed to allocate memory for kernel PML4!");
+
+        uint64_t hhdm = Boot::Limine::HhdmRequest.response->offset;
+        __builtin_memset(reinterpret_cast<void *>(pml4Phys + hhdm), 0, sizeof(PML4));
+
+        _kernelState.pml4 = reinterpret_cast<PML4 *>(pml4Phys);
+
+        CopyExistingPageTableToNew(&_kernelState, hhdm);
+        ReserveHigherHalfPML4Slots(&_kernelState, hhdm);
+
+        SwitchToKernelPageTable();
+
+        LOG_INFO("Kernel paging initialized with PML4 at physical address {}", (void*)pml4Phys);
+    }
+
+    void Paging::MapPage(State *state, uint64_t virtualAddress, uint64_t physicalAddress, Flags flags) {
+        if (virtualAddress & (Architecture::PageSize - 1)) PANIC("Virtual address is not page-aligned!");
+        if (physicalAddress & (Architecture::PageSize - 1)) PANIC("Physical address is not page-aligned!");
+
+        Threading::ScopedLock lock(state->lock, true);
+
+        auto offset = Boot::Limine::HhdmRequest.response->offset;
+
+        uint64_t entryFlags = static_cast<uint64_t>(flags) | static_cast<uint64_t>(Flags::Present);
+        auto directoryFlags = static_cast<uint64_t>(Flags::Present | Flags::ReadWrite | Flags::User);
+
+        uint32_t pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset;
+        ExtractPageTableIndices(virtualAddress, pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset);
+
+        PML4* pml4 = reinterpret_cast<PML4 *>(reinterpret_cast<uint64_t>(state->pml4) + offset);
+        if (!pml4->entries[pml4Index]) {
+            // Allocate a new PDP table
+            PDP* newPdp = reinterpret_cast<PDP *>(_pmm.AllocatePages(1));
+            if (!newPdp) PANIC("Failed to allocate memory for new PDP table!");
+            __builtin_memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(newPdp) + offset), 0, sizeof(PDP)); // Clear the new table
+            pml4->entries[pml4Index] = reinterpret_cast<uint64_t>(newPdp) | directoryFlags;
+        }
+
+        uintptr_t pdpPhysicalAddress = pml4->entries[pml4Index] & PointerMask;
+        PDP* pdp = reinterpret_cast<PDP *>(reinterpret_cast<uint64_t>(pdpPhysicalAddress) + offset);
+        if (!pdp->entries[pdpIndex]) {
+            // Allocate a new PD table
+            PD* newPd = reinterpret_cast<PD *>(_pmm.AllocatePages(1));
+            if (!newPd) PANIC("Failed to allocate memory for new PD table!");
+            __builtin_memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(newPd) + offset), 0, sizeof(PD)); // Clear the new table
+            pdp->entries[pdpIndex] = reinterpret_cast<uint64_t>(newPd) | directoryFlags;
+        }
+
+        uintptr_t pdPhysicalAddress = pdp->entries[pdpIndex] & PointerMask;
+        PD* pd = reinterpret_cast<PD *>(reinterpret_cast<uint64_t>(pdPhysicalAddress) + offset);
+        if (!pd->entries[pdIndex]) {
+            // Allocate a new PT table
+            PT* newPt = reinterpret_cast<PT *>(_pmm.AllocatePages(1));
+            if (!newPt) PANIC("Failed to allocate memory for new PT table!");
+            __builtin_memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(newPt) + offset), 0, sizeof(PT)); // Clear the new table
+            pd->entries[pdIndex] = reinterpret_cast<uint64_t>(newPt) | directoryFlags;
+        }
+
+        uintptr_t ptPhysicalAddress = pd->entries[pdIndex] & PointerMask;
+        PT* pt = reinterpret_cast<PT *>(reinterpret_cast<uint64_t>(ptPhysicalAddress) + offset);
+        if (pt->entries[ptIndex] & static_cast<uint64_t>(Flags::Present)) {
+            LOG_ERROR("Virtual address {} is already mapped to physical address {} with flags {}", virtualAddress, pt->entries[ptIndex] & PointerMask, pt->entries[ptIndex] & FlagsMask);
+            PANIC("Virtual address is already mapped");
+        }
+
+        pt->entries[ptIndex] = (physicalAddress & PointerMask) | entryFlags;
+        asm volatile("invlpg (%0)" ::"r"(virtualAddress) : "memory"); // Invalidate the TLB entry for this page to ensure the new mapping is used immediately
+    }
+
+    void Paging::UnmapPage(State *state, uint64_t virtualAddress) {
+        Threading::ScopedLock lock(state->lock, true);
+
+        // Reverse of the mapping process, but we also need to check if the page tables are present at each level and panic if we try to unmap an address that isn't mapped
+        uint32_t pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset;
+        ExtractPageTableIndices(virtualAddress, pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset);
+
+        auto offset = Boot::Limine::HhdmRequest.response->offset;
+
+        PML4* pml4 = reinterpret_cast<PML4 *>(reinterpret_cast<uint64_t>(state->pml4) + offset);
+        if (!(pml4->entries[pml4Index] & static_cast<uint64_t>(Flags::Present))) PANIC("Attempted to unmap a virtual address that is not mapped (PML4 entry not present)!");
+
+        uintptr_t pdpPhysicalAddress = pml4->entries[pml4Index] & PointerMask;
+        PDP* pdp = reinterpret_cast<PDP *>(reinterpret_cast<uint64_t>(pdpPhysicalAddress) + offset);
+        if (!(pdp->entries[pdpIndex] & static_cast<uint64_t>(Flags::Present))) PANIC("Attempted to unmap a virtual address that is not mapped (PDP entry not present)!");
+
+        uintptr_t pdPhysicalAddress = pdp->entries[pdpIndex] & PointerMask;
+        PD* pd = reinterpret_cast<PD *>(reinterpret_cast<uint64_t>(pdPhysicalAddress) + offset);
+        if (!(pd->entries[pdIndex] & static_cast<uint64_t>(Flags::Present))) PANIC("Attempted to unmap a virtual address that is not mapped (PD entry not present)!");
+
+        uintptr_t ptPhysicalAddress = pd->entries[pdIndex] & PointerMask;
+        PT* pt = reinterpret_cast<PT *>(reinterpret_cast<uint64_t>(ptPhysicalAddress) + offset);
+        if (!(pt->entries[ptIndex] & static_cast<uint64_t>(Flags::Present))) PANIC("Attempted to unmap a virtual address that is not mapped (PT entry not present)!");
+
+        pt->entries[ptIndex] = 0; // Clear the entry to unmap the page
+        asm volatile("invlpg (%0)" ::"r"(virtualAddress) : "memory"); // Invalidate the TLB entry for this page to ensure the unmapping takes effect immediately
+
+        // Check if PT is now empty, and if so, free it and clear the PD entry
+        if (IsTableEmpty(reinterpret_cast<uint64_t*>(pt))) {
+            _pmm.FreePages(ptPhysicalAddress, 1);
+            pd->entries[pdIndex] = 0;
+
+            // Check if PD is now empty, and if so, free it and clear the PDP entry
+            if (IsTableEmpty(reinterpret_cast<uint64_t*>(pd))) {
+                _pmm.FreePages(pdPhysicalAddress, 1);
+                pdp->entries[pdpIndex] = 0;
+
+                // Check if PDP is now empty, and if so, free it and clear the PML4 entry
+                // Do not free kernel page tables.
+                if (IsTableEmpty(reinterpret_cast<uint64_t*>(pdp)) && pml4Index < 256) {
+                    _pmm.FreePages(pdpPhysicalAddress, 1);
+                    pml4->entries[pml4Index] = 0;
+                }
+            }
+        }
+    }
+
+    uint64_t Paging::GetPhysicalAddress(State *state, uint64_t virtualAddress) {
+        Threading::ScopedLock lock(state->lock, true);
+
+        uint32_t pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset;
+        ExtractPageTableIndices(virtualAddress, pml4Index, pdpIndex, pdIndex, ptIndex, pageOffset);
+
+        auto offset = Boot::Limine::HhdmRequest.response->offset;
+
+        auto pml4 = reinterpret_cast<PML4 *>(reinterpret_cast<uint64_t>(state->pml4) + offset);
+        if (!(pml4->entries[pml4Index] & static_cast<uint64_t>(Flags::Present))) return 0;
+
+        uintptr_t pdpPhysicalAddress = pml4->entries[pml4Index] & PointerMask;
+        auto pdp = reinterpret_cast<PDP *>(reinterpret_cast<uint64_t>(pdpPhysicalAddress) + offset);
+        if (!(pdp->entries[pdpIndex] & static_cast<uint64_t>(Flags::Present))) return 0;
+
+        uintptr_t pdPhysicalAddress = pdp->entries[pdpIndex] & PointerMask;
+        auto pd = reinterpret_cast<PD *>(reinterpret_cast<uint64_t>(pdPhysicalAddress) + offset);
+        if (!(pd->entries[pdIndex] & static_cast<uint64_t>(Flags::Present))) return 0;
+
+        uintptr_t ptPhysicalAddress = pd->entries[pdIndex] & PointerMask;
+        auto pt = reinterpret_cast<PT *>(reinterpret_cast<uint64_t>(ptPhysicalAddress) + offset);
+        if (!(pt->entries[ptIndex] & static_cast<uint64_t>(Flags::Present))) return 0;
+
+        uintptr_t pagePhysicalAddress = pt->entries[ptIndex] & PointerMask;
+        return pagePhysicalAddress | pageOffset;
+    }
+
+    bool Paging::IsMapped(State *state, uint64_t virtualAddress) {
+        if (GetPhysicalAddress(state, virtualAddress) != 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    void Paging::SwitchToKernelPageTable() {
+        SwitchToPageTable(&_kernelState);
+    }
+
+    void Paging::SwitchToPageTable(State *state) {
+        asm volatile("mov %0, %%cr3" :: "r"(reinterpret_cast<uintptr_t>(state->pml4)) : "memory");
+        Kernel::GetInstance().GetCpuData()->pageState = state;
+    }
+
+    void Paging::ReserveHigherHalfPML4Slots(State *state, uint64_t higherHalf) const {
+        auto *pml4 = reinterpret_cast<PML4 *>(reinterpret_cast<uintptr_t>(state->pml4) + higherHalf);
+        auto flags = static_cast<uint64_t>(Flags::Present | Flags::ReadWrite);
+
+        for (int i = 256; i < 512; i++) { // canonical higher half
+            if (pml4->entries[i] & static_cast<uint64_t>(Flags::Present)) continue;
+
+            uintptr_t pdpPhys = _pmm.AllocatePages(1);
+            if (!pdpPhys) PANIC("Failed to allocate memory for reserved PDP table!");
+            __builtin_memset(reinterpret_cast<void *>(pdpPhys + higherHalf), 0, sizeof(PDP));
+            pml4->entries[i] = pdpPhys | flags;
+        }
+    }
+
+    void Paging::CopyExistingPageTableToNew(State *state, uint64_t higherHalf) {
+        uint64_t cr3;
+        asm volatile("mov %%cr3, %0" : "=r"(cr3));
+
+        auto *liminePml4 = reinterpret_cast<PML4 *>(cr3 + higherHalf);
+        auto *newPml4 = reinterpret_cast<PML4 *>(reinterpret_cast<uintptr_t>(state->pml4) + higherHalf);
+
+        for (int i = 0; i < 512; i++) {
+            if (!(liminePml4->entries[i] & static_cast<uint64_t>(Flags::Present))) continue;
+
+            uint64_t srcPhys = liminePml4->entries[i] & PointerMask;
+            uintptr_t dstPhys = _pmm.AllocatePages(1);
+            if (!dstPhys)
+                PANIC("Failed to allocate memory for page table during deep copy!");
+
+            DeepCopyPageTables(3, srcPhys, dstPhys, higherHalf);
+            newPml4->entries[i] = (liminePml4->entries[i] & FlagsMask) | dstPhys;
+        }
+    }
+
+    void Paging::DeepCopyPageTables(uint32_t level, uintptr_t srcPhys, uintptr_t dstPhys, uint64_t higherHalf) {
+        auto srcTable = reinterpret_cast<uint64_t*>(srcPhys + higherHalf);
+        auto dstTable = reinterpret_cast<uint64_t*>(dstPhys + higherHalf);
+
+        for (int i = 0; i < 512; i++) {
+            if (!(srcTable[i] & static_cast<uint64_t>(Flags::Present))) continue;
+
+            // If the entry is a huge page, we can copy it directly, since huge pages are leaf entries.
+            if ((level == 3 || level == 2) && (srcTable[i] & static_cast<uint64_t>(Flags::HugePage))) {
+                dstTable[i] = srcTable[i];
+                continue;
+            }
+
+            // If level is 1, we are at the PT level and can copy the entries directly
+            if (level == 1) {
+                dstTable[i] = srcTable[i];
+                continue;
+            }
+
+            // Otherwise, allocate a new table for the next level
+            uintptr_t newTablePhys = _pmm.AllocatePages(1);
+            __builtin_memset(reinterpret_cast<void*>(newTablePhys + higherHalf), 0, 4096);
+
+            // Link the new table into the destination hierarchy
+            uint64_t flags = srcTable[i] & FlagsMask;
+            dstTable[i] = newTablePhys | flags;
+
+            uintptr_t nextSrcPhys = srcTable[i] & PointerMask;
+            uintptr_t nextDstPhys = newTablePhys;
+            DeepCopyPageTables(level - 1, nextSrcPhys, nextDstPhys, higherHalf);
+        }
+    }
+
+    bool Paging::IsTableEmpty(const uint64_t *table) {
+        for (size_t i = 0; i < 512; i++) {
+            if (table[i] & static_cast<uint64_t>(Flags::Present)) return false;
+        }
+        return true;
+    }
+
+    // https://wiki.osdev.org/Page_Tables#Long_mode_(64-bit)_page_map
+    // https://upload.wikimedia.org/wikipedia/commons/9/9b/X86_Paging_64bit.svg
+    void Paging::ExtractPageTableIndices(uint64_t vaddr, uint32_t &pml4Index, uint32_t &pdpIndex, uint32_t &pdIndex,
+        uint32_t &ptIndex, uint32_t &pageIndex) {
+        pml4Index = (vaddr >> 39) & 0x1FF;
+        pdpIndex = (vaddr >> 30) & 0x1FF;
+        pdIndex = (vaddr >> 21) & 0x1FF;
+        ptIndex = (vaddr >> 12) & 0x1FF;
+        pageIndex = vaddr & 0xFFF; // lower 12 bits are the offset within the page
+    }
+} // Memory

--- a/src/kernel/Memory/Paging.h
+++ b/src/kernel/Memory/Paging.h
@@ -1,0 +1,79 @@
+#ifndef BOREALOS_PAGING_H
+#define BOREALOS_PAGING_H
+
+#include <Definitions.h>
+
+#include "PhysicalMemoryManager.h"
+
+namespace Memory {
+    class Paging {
+    private:
+        struct PT { uint64_t entries[512]; } ALIGNED(Architecture::PageSize);
+        struct PD { uint64_t entries[512]; } ALIGNED(Architecture::PageSize);
+        struct PDP { uint64_t entries[512]; } ALIGNED(Architecture::PageSize);
+        struct PML4 { uint64_t entries[512]; } ALIGNED(Architecture::PageSize);
+
+    public:
+        enum class Flags : uint64_t {
+            Present = 1 << 0,
+            ReadWrite = 1 << 1,
+            User = 1 << 2,
+            WriteThrough = 1 << 3,
+            CacheDisable = 1 << 4,
+            Accessed = 1 << 5,
+            Dirty = 1 << 6,
+            HugePage = 1 << 7,
+            Global = 1 << 8,
+            NoExecute = 1ULL << 63,
+        };
+
+        struct State {
+            PML4 *pml4{};
+            Threading::Spinlock lock{};
+        };
+
+        struct AvailableVirtualAddressRange {
+            uint64_t start;
+            uint64_t end;
+        };
+
+        explicit Paging(PhysicalMemoryManager& pmm);
+
+        void Initialize();
+
+        void MapPage(State *state, uint64_t virtualAddress, uint64_t physicalAddress, Flags flags);
+        void UnmapPage(State *state, uint64_t virtualAddress);
+
+        uint64_t GetPhysicalAddress(State *state, uint64_t virtualAddress);
+        [[nodiscard]] bool IsMapped(State *state, uint64_t virtualAddress);
+
+        void SwitchToKernelPageTable();
+        static void SwitchToPageTable(State *state);
+
+    private:
+        Threading::Spinlock _lock;
+        PhysicalMemoryManager& _pmm;
+        State _kernelState;
+
+        static constexpr uint64_t PointerMask = 0x000FFFFFFFFFF000; // Mask to get the address portion of a page table entry
+        static constexpr uint64_t FlagsMask = 0xFFF0000000000FFF; // Mask to get the flags portion of a page table entry
+
+        void ReserveHigherHalfPML4Slots(State *state, uint64_t higherHalf) const;
+        void CopyExistingPageTableToNew(State *state, uint64_t higherHalf);
+        void DeepCopyPageTables(uint32_t level, uintptr_t srcPhys, uintptr_t dstPhys, uint64_t higherHalf);
+
+        static bool IsTableEmpty(const uint64_t *table);
+        static inline void ExtractPageTableIndices(uint64_t vaddr, uint32_t& pml4Index, uint32_t& pdpIndex, uint32_t& pdIndex, uint32_t& ptIndex, uint32_t& pageIndex);
+    };
+
+    constexpr Paging::Flags operator|(Paging::Flags a, Paging::Flags b) {
+        return static_cast<Paging::Flags>(static_cast<uint64_t>(a) | static_cast<uint64_t>(b));
+    }
+
+    constexpr Paging::Flags operator|=(Paging::Flags& a, Paging::Flags b) {
+        a = a | b;
+        return a;
+    }
+} // Memory
+
+#endif //BOREALOS_PAGING_H

--- a/src/kernel/Memory/PhysicalMemoryManager.cpp
+++ b/src/kernel/Memory/PhysicalMemoryManager.cpp
@@ -40,9 +40,9 @@ namespace Memory {
             validRegionCount++;
         }
 
-        _usableFrames = endAddr / Constants::PageSize;
+        _usableFrames = endAddr / Architecture::PageSize;
         _bitmapSize = (_usableFrames + 7) / 8;
-        _bitmapSize = Utility::Math::AlignUp(_bitmapSize, Constants::PageSize);
+        _bitmapSize = Utility::Math::AlignUp(_bitmapSize, Architecture::PageSize);
 
         LOG_DEBUG("Usable frames: {}, Bitmap size: {} bytes", _usableFrames, _bitmapSize);
 
@@ -50,8 +50,8 @@ namespace Memory {
         void* bitmapMemory = nullptr;
 
         for (uint64_t regionIndex = 0; regionIndex < validRegionCount; regionIndex++) {
-            auto start = Utility::Math::AlignUp(validRegions[regionIndex].addr, Constants::PageSize);
-            auto end = Utility::Math::AlignDown(validRegions[regionIndex].addr + validRegions[regionIndex].length, Constants::PageSize);
+            auto start = Utility::Math::AlignUp(validRegions[regionIndex].addr, Architecture::PageSize);
+            auto end = Utility::Math::AlignDown(validRegions[regionIndex].addr + validRegions[regionIndex].length, Architecture::PageSize);
             auto size = (end > start) ? (end - start) : 0;
 
             if (size >= requiredMapStorageSize) {
@@ -75,11 +75,11 @@ namespace Memory {
         }
 
         for (uint64_t regionIndex = 0; regionIndex < validRegionCount; regionIndex++) {
-            auto start = Utility::Math::AlignUp(validRegions[regionIndex].addr, Constants::PageSize);
-            auto end = Utility::Math::AlignDown(validRegions[regionIndex].addr + validRegions[regionIndex].length, Constants::PageSize);
+            auto start = Utility::Math::AlignUp(validRegions[regionIndex].addr, Architecture::PageSize);
+            auto end = Utility::Math::AlignDown(validRegions[regionIndex].addr + validRegions[regionIndex].length, Architecture::PageSize);
 
-            for (uint64_t addr = start; addr < end; addr += Constants::PageSize) {
-                uint64_t frameIndex = addr / Constants::PageSize;
+            for (uint64_t addr = start; addr < end; addr += Architecture::PageSize) {
+                uint64_t frameIndex = addr / Architecture::PageSize;
                 uint64_t byteIndex = frameIndex / 8;
                 uint8_t bitIndex = frameIndex % 8;
 
@@ -88,7 +88,7 @@ namespace Memory {
         }
 
         // Mark the first 1MB as reserved
-        for (uint64_t page = 0; page < (1 * Constants::MiB) / Constants::PageSize; page++) {
+        for (uint64_t page = 0; page < (1 * Constants::MiB) / Architecture::PageSize; page++) {
             uint64_t byteIndex = page / 8;
             uint8_t bitIndex = page % 8;
 
@@ -96,8 +96,8 @@ namespace Memory {
         }
 
         // Reserve the 2 bitmaps
-        auto bitmapStart = (uint64_t)((uintptr_t)bitmapMemory / Constants::PageSize);
-        auto bitmapEnd = Utility::Math::AlignUp(bitmapStart + requiredMapStorageSize, Constants::PageSize) / Constants::PageSize;
+        auto bitmapStart = (uint64_t)((uintptr_t)bitmapMemory / Architecture::PageSize);
+        auto bitmapEnd = Utility::Math::AlignUp(bitmapStart + requiredMapStorageSize, Architecture::PageSize) / Architecture::PageSize;
 
         for (uint64_t page = bitmapStart; page < bitmapEnd; page++) {
             uint64_t byteIndex = page / 8;
@@ -127,7 +127,7 @@ namespace Memory {
             PANIC("Failed test case");
         }
 
-        LOG_INFO("Device has {} MiB, with {} MiB available", (_frameCount * Constants::PageSize) / (Constants::MiB), (_usableFrames * Constants::PageSize) / (Constants::MiB));
+        LOG_INFO("Device has {} MiB, with {} MiB available", (_frameCount * Architecture::PageSize) / (Constants::MiB), (_usableFrames * Architecture::PageSize) / (Constants::MiB));
     }
 
     uintptr_t PhysicalMemoryManager::AllocatePages(size_t pageCount) {
@@ -166,18 +166,18 @@ namespace Memory {
 
         _usableFrames -= pageCount;
 
-        return (runStart * Constants::PageSize);
+        return (runStart * Architecture::PageSize);
     }
 
     void PhysicalMemoryManager::FreePages(uintptr_t start, size_t pageCount) {
         Threading::ScopedLock lock(_lock, true);
 
-        if (start % Constants::PageSize != 0) {
+        if (start % Architecture::PageSize != 0) {
             PANIC("Invalid page start address");
             return;
         }
 
-        size_t startPage = start / Constants::PageSize;
+        size_t startPage = start / Architecture::PageSize;
         size_t endPage = startPage + pageCount;
 
         for (size_t page = startPage; page < endPage; page++) {
@@ -207,7 +207,7 @@ namespace Memory {
         uintptr_t twoPages = AllocatePages(2);
 
         size_t amount = 10;
-        uintptr_t megabytes = AllocatePages(amount * Constants::MiB / Constants::PageSize);
+        uintptr_t megabytes = AllocatePages(amount * Constants::MiB / Architecture::PageSize);
 
         if (!onePage) {
             LOG_ERROR("Failed to allocate 1 page");
@@ -225,7 +225,7 @@ namespace Memory {
 
         FreePages(onePage, 1);
         FreePages(twoPages, 2);
-        FreePages(megabytes, amount * Constants::MiB / Constants::PageSize);
+        FreePages(megabytes, amount * Constants::MiB / Architecture::PageSize);
 
         // Reallocate each page, it should produce the exact same result as before.
         uintptr_t oldOnePage = onePage, oldTwoPages = twoPages, oldFiveMegabytes = megabytes;
@@ -233,7 +233,7 @@ namespace Memory {
 
         onePage = AllocatePages(1);
         twoPages = AllocatePages(2);
-        megabytes = AllocatePages(amount * Constants::MiB / Constants::PageSize);
+        megabytes = AllocatePages(amount * Constants::MiB / Architecture::PageSize);
 
         if (onePage != oldOnePage) {
             LOG_ERROR("Reallocated 1 page at {}, expected {}", (void*)onePage, (void*)oldOnePage);
@@ -247,7 +247,7 @@ namespace Memory {
 
         FreePages(onePage, 1);
         FreePages(twoPages, 2);
-        FreePages(megabytes, amount * Constants::MiB / Constants::PageSize);
+        FreePages(megabytes, amount * Constants::MiB / Architecture::PageSize);
 
         LOG_DEBUG("Successful test!");
 


### PR DESCRIPTION
LimineDefinitions:
Add a MP request

TSS/IDT/GDT:
Port of v3, but for GDT and TSS, it now has per cpu support using uint32_t cpuId.
IDT does not yet call EOI

FramebufferConsole:
Add lock

Paging:
Port of v3, but with multicore support and architectural changes.
It uses a shared upper half of memory for the entire kernel.

Pmm:
Rename constants::pagesize to architecture::

Architecture:
Same as v3, i did not add this previously, but realised it would still be useful to have so added it back

Kernel:
Add GetCpuData(); function and Cpu array
In initialize, the GDT initializes the cpuId from mp->bsp_lapic_id, and initialize paging & idt

KernelData:
Add CpuData struct with a pageState

Logging:
Add a lock to LOG_ commands, otherwise it will interrupt each other, which was not a fatal bug, but 2 things writing at the same time meant... both things were written through each other!